### PR TITLE
Prefer condensed game highlights over longer recap

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,11 +72,21 @@ function extractHighlightUrl(game) {
     return null;
   }
 
-  const recap =
-    items.find((item) => /recap|condensed|cg:/i.test(item.title || item.headline)) ||
+  console.log(
+    `Available highlight items for game ${game.gamePk}: ` +
+      items.map((i) => `"${i.title || i.headline}"`).join(", ")
+  );
+
+  // Prefer shorter highlights/condensed game over the longer recap
+  const selected =
+    items.find((item) => /condensed|cg:/i.test(item.title || item.headline)) ||
+    items.find((item) => /highlight/i.test(item.title || item.headline)) ||
+    items.find((item) => /recap/i.test(item.title || item.headline)) ||
     items[0];
 
-  const playbacks = recap?.playbacks;
+  console.log(`Selected: "${selected.title || selected.headline}"`);
+
+  const playbacks = selected?.playbacks;
   if (!playbacks?.length) {
     console.log(`Highlight item found but no playbacks for game ${game.gamePk}.`);
     return null;


### PR DESCRIPTION
## Summary
- Reorder video selection priority: Condensed Game > Highlights > Recap
- Previously "Recap" (10+ min) was matched first; now shorter highlight videos are preferred
- Added logging of all available video items for easier debugging

## Test plan
- [ ] Merge and trigger workflow manually
- [ ] Check logs for the "Available highlight items" line to see what MLB returns
- [ ] Verify the email links to the shorter highlights video, not the long recap

https://claude.ai/code/session_01Gv2xJgdaP9vPpKMsfjx41e