### PR TITLE
Widen cron schedule to hourly across all US game times

### DIFF
--- a/.github/workflows/highlights.yml
+++ b/.github/workflows/highlights.yml
@@ -2,10 +2,11 @@ name: Mariners Highlights Emailer
 
 on:
   schedule:
-    # Every 30 min from 02:00-08:30 UTC (covers ~6 PM - 1 AM Pacific)
-    - cron: '0,30 2-8 * * *'
-    # 09:00 UTC catch-all for late West Coast games
-    - cron: '0 9 * * *'
+    # Hourly from 23:00-08:00 UTC (3 PM - 12 AM Pacific), covers all US time zones
+    - cron: '0 23 * * *'
+    - cron: '0 0-8 * * *'
+    # 10:00 UTC (2 AM Pacific) catch-all for extra-inning games
+    - cron: '0 10 * * *'
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
## Summary
- Run hourly from 3 PM to midnight Pacific (23:00–08:00 UTC), plus a 2 AM Pacific catch-all
- Covers east coast early games (~4 PM PT) through late west coast extra-inning games
- ~11 runs/day instead of ~15, wider coverage

## Schedule (UTC → Pacific)
| UTC | Pacific |
|---|---|
| 23:00 | 3:00 PM |
| 00:00–08:00 | 4:00 PM – 12:00 AM |
| 10:00 | 2:00 AM (catch-all) |

https://claude.ai/code/session_01Gv2xJgdaP9vPpKMsfjx41e