### PR TITLE
Prefix MLB tables with mlb_ for shared Supabase project

### DIFF
--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -24,7 +24,7 @@ export async function GET(request) {
 
   // 1. Get all team IDs that at least one user follows
   const { data: subscribedTeams } = await supabase
-    .from("user_teams")
+    .from("mlb_user_teams")
     .select("team_id")
     .limit(1000);
 
@@ -48,7 +48,7 @@ export async function GET(request) {
         for (const game of finals) {
           // Check if we already have this game cached with a highlight URL
           const { data: cached } = await supabase
-            .from("game_cache")
+            .from("mlb_game_cache")
             .select("highlight_url")
             .eq("game_pk", game.gamePk)
             .single();
@@ -69,7 +69,7 @@ export async function GET(request) {
           const url = extractHighlightUrl(content);
 
           // Upsert into game_cache
-          await supabase.from("game_cache").upsert({
+          await supabase.from("mlb_game_cache").upsert({
             game_pk: game.gamePk,
             team_id: teamId,
             game_date: dateStr,
@@ -105,20 +105,20 @@ export async function GET(request) {
   for (const game of newGames) {
     // Get users following this team who haven't been notified for this game
     const { data: users } = await supabase
-      .from("user_teams")
-      .select("user_id, users!inner(email)")
+      .from("mlb_user_teams")
+      .select("user_id, mlb_users!inner(email)")
       .eq("team_id", game.teamId);
 
     if (!users?.length) continue;
 
     for (const row of users) {
       const userId = row.user_id;
-      const email = row.users?.email;
+      const email = row.mlb_users?.email;
       if (!email) continue;
 
       // Check if already notified
       const { data: existing } = await supabase
-        .from("sent_notifications")
+        .from("mlb_sent_notifications")
         .select("id")
         .eq("user_id", userId)
         .eq("game_pk", game.gamePk)
@@ -135,7 +135,7 @@ export async function GET(request) {
       try {
         await sendEmail(email, subject, html);
 
-        await supabase.from("sent_notifications").insert({
+        await supabase.from("mlb_sent_notifications").insert({
           user_id: userId,
           game_pk: game.gamePk,
         });

--- a/app/api/unsubscribe/route.js
+++ b/app/api/unsubscribe/route.js
@@ -13,7 +13,7 @@ export async function POST(request) {
   // The token is the user's ID, signed/encoded in the email link.
   // For MVP, we use the user ID directly. In production, use a signed JWT.
   const { error } = await supabase
-    .from("user_teams")
+    .from("mlb_user_teams")
     .delete()
     .eq("user_id", token);
 

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -12,7 +12,7 @@ export default async function DashboardPage() {
   if (!user) redirect("/login");
 
   const { data: userTeams } = await supabase
-    .from("user_teams")
+    .from("mlb_user_teams")
     .select("team_id")
     .eq("user_id", user.id);
 

--- a/app/dashboard/team-grid.js
+++ b/app/dashboard/team-grid.js
@@ -24,12 +24,12 @@ export default function TeamGrid({ teams, followedIds: initialFollowed }) {
 
     if (isFollowing) {
       await supabase
-        .from("user_teams")
+        .from("mlb_user_teams")
         .delete()
         .eq("team_id", teamId);
     } else {
       await supabase
-        .from("user_teams")
+        .from("mlb_user_teams")
         .insert({ team_id: teamId });
     }
 

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -1,7 +1,8 @@
--- Run this in the Supabase SQL editor to set up the database.
+-- Run this in the Supabase SQL editor to set up the MLB highlights tables.
+-- All tables are prefixed with mlb_ to avoid conflicts with other apps sharing this project.
 
 -- User team subscriptions
-create table public.user_teams (
+create table public.mlb_user_teams (
   user_id uuid references auth.users(id) on delete cascade not null,
   team_id integer not null,
   created_at timestamptz default now() not null,
@@ -9,7 +10,7 @@ create table public.user_teams (
 );
 
 -- Game cache (one row per game, shared across all users)
-create table public.game_cache (
+create table public.mlb_game_cache (
   game_pk integer primary key,
   team_id integer not null,
   game_date date not null,
@@ -19,7 +20,7 @@ create table public.game_cache (
 );
 
 -- Sent notification tracking (prevents duplicate emails)
-create table public.sent_notifications (
+create table public.mlb_sent_notifications (
   id uuid default gen_random_uuid() primary key,
   user_id uuid references auth.users(id) on delete cascade not null,
   game_pk integer not null,
@@ -28,39 +29,39 @@ create table public.sent_notifications (
 );
 
 -- Indexes for common queries
-create index idx_user_teams_team_id on public.user_teams(team_id);
-create index idx_game_cache_team_date on public.game_cache(team_id, game_date);
-create index idx_sent_notifications_user_game on public.sent_notifications(user_id, game_pk);
+create index idx_mlb_user_teams_team_id on public.mlb_user_teams(team_id);
+create index idx_mlb_game_cache_team_date on public.mlb_game_cache(team_id, game_date);
+create index idx_mlb_sent_notifications_user_game on public.mlb_sent_notifications(user_id, game_pk);
 
 -- Row Level Security
-alter table public.user_teams enable row level security;
-alter table public.game_cache enable row level security;
-alter table public.sent_notifications enable row level security;
+alter table public.mlb_user_teams enable row level security;
+alter table public.mlb_game_cache enable row level security;
+alter table public.mlb_sent_notifications enable row level security;
 
--- user_teams: users can read/write their own rows
-create policy "Users can view their own teams"
-  on public.user_teams for select
+-- mlb_user_teams: users can read/write their own rows
+create policy "Users can view their own MLB teams"
+  on public.mlb_user_teams for select
   using (auth.uid() = user_id);
 
-create policy "Users can insert their own teams"
-  on public.user_teams for insert
+create policy "Users can insert their own MLB teams"
+  on public.mlb_user_teams for insert
   with check (auth.uid() = user_id);
 
-create policy "Users can delete their own teams"
-  on public.user_teams for delete
+create policy "Users can delete their own MLB teams"
+  on public.mlb_user_teams for delete
   using (auth.uid() = user_id);
 
--- game_cache: readable by everyone (public data), writable by service role only
-create policy "Anyone can read game cache"
-  on public.game_cache for select
+-- mlb_game_cache: readable by everyone (public data), writable by service role only
+create policy "Anyone can read MLB game cache"
+  on public.mlb_game_cache for select
   using (true);
 
--- sent_notifications: users can read their own
-create policy "Users can view their own notifications"
-  on public.sent_notifications for select
+-- mlb_sent_notifications: users can read their own
+create policy "Users can view their own MLB notifications"
+  on public.mlb_sent_notifications for select
   using (auth.uid() = user_id);
 
--- Create a view to join user_teams with auth.users for the cron worker
+-- Create a view to join mlb_user_teams with auth.users for the cron worker
 -- (The cron worker uses the service role key which bypasses RLS)
-create view public.users as
+create view public.mlb_users as
   select id, email from auth.users;


### PR DESCRIPTION
## Summary

- Renames all database tables and views with `mlb_` prefix to avoid conflicts with existing tables in the shared Supabase project
- `user_teams` → `mlb_user_teams`, `game_cache` → `mlb_game_cache`, `sent_notifications` → `mlb_sent_notifications`, `users` view → `mlb_users`
- Updates all code references, RLS policies, and indexes

## Test plan

- [ ] Verify `npm run build` succeeds
- [ ] Run updated `supabase-schema.sql` — confirm new tables don't conflict with existing `portfolios`, `portfolio_holdings`, etc.

https://claude.ai/code/session_01Gv2xJgdaP9vPpKMsfjx41e