### PR TITLE
Debug missing email: improved highlight extraction and error reporting

### DIFF
--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -107,6 +107,8 @@ export async function GET(request) {
 
   // 3. For each game with highlights, find users to notify
   let emailsSent = 0;
+  const errors = [];
+  const skipped = [];
 
   for (const game of newGames) {
     const { data: subscribers } = await supabase
@@ -114,7 +116,10 @@ export async function GET(request) {
       .select("user_id")
       .eq("team_id", game.teamId);
 
-    if (!subscribers?.length) continue;
+    if (!subscribers?.length) {
+      skipped.push({ gamePk: game.gamePk, reason: "no_subscribers" });
+      continue;
+    }
 
     for (const row of subscribers) {
       const userId = row.user_id;
@@ -126,7 +131,10 @@ export async function GET(request) {
         .single();
 
       const email = userData?.email;
-      if (!email) continue;
+      if (!email) {
+        skipped.push({ gamePk: game.gamePk, userId, reason: "no_email" });
+        continue;
+      }
 
       // Check if already notified
       const { data: existing } = await supabase
@@ -136,7 +144,10 @@ export async function GET(request) {
         .eq("game_pk", game.gamePk)
         .maybeSingle();
 
-      if (existing) continue;
+      if (existing) {
+        skipped.push({ gamePk: game.gamePk, reason: "already_notified" });
+        continue;
+      }
 
       // Send email
       const team = TEAMS_BY_ID[game.teamId];
@@ -154,13 +165,17 @@ export async function GET(request) {
 
         emailsSent++;
       } catch (err) {
-        console.error(`Failed to email ${email} for game ${game.gamePk}:`, err.message);
+        const errMsg = `Failed to email ${email} for game ${game.gamePk}: ${err.message}`;
+        console.error(errMsg);
+        errors.push(errMsg);
       }
     }
   }
 
   return NextResponse.json({
     message: `Processed ${newGames.length} games, sent ${emailsSent} emails`,
+    errors: errors.length > 0 ? errors : undefined,
+    skipped: skipped.length > 0 ? skipped : undefined,
   });
 }
 


### PR DESCRIPTION
## Summary
- **Highlight extraction**: Added fallback to `media.epg` path in case MLB API moved recaps from legacy `highlights.highlights.items` format
- **Date coverage**: Switched timezone to Eastern and now checks 3 days back instead of 2 to avoid edge-case misses
- **Error reporting**: Cron response now includes `errors` (Brevo failures) and `skipped` (with reasons like `already_notified`, `no_email`, `no_subscribers`) instead of silently swallowing failures

## Test plan
- [ ] Merge and deploy, then run `curl -H "Authorization: Bearer my-secret-123" https://mlb.nmartinovic.workers.dev/api/cron`
- [ ] Check response for `errors` and `skipped` fields to identify why April 4 email didn't send
- [ ] Verify next game day email arrives at 9am Paris time

https://claude.ai/code/session_016owYtKw83CdXWNqUdMKXTG