### PR TITLE
Persist SITE_URL and FROM_EMAIL in wrangler config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,10 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
+  "vars": {
+    "SITE_URL": "https://mlb.nmartinovic.workers.dev",
+    "FROM_EMAIL": "info@nickmartinovic.com"
+  },
   "triggers": {
     "crons": ["0 * * * *"]
   }


### PR DESCRIPTION
## Summary
- Cloudflare deploys were wiping env vars not defined in wrangler.jsonc
- Added `SITE_URL` and `FROM_EMAIL` to `vars` so they persist across deploys

## Test plan
- [ ] Merge and run `npm run deploy`
- [ ] Confirm vars are present in Cloudflare dashboard after deploy

https://claude.ai/code/session_016owYtKw83CdXWNqUdMKXTG