### PR TITLE
Add observability config and build command for cron handler

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,6 +12,12 @@
     "SITE_URL": "https://mlb.nmartinovic.workers.dev",
     "FROM_EMAIL": "info@nickmartinovic.com"
   },
+  "observability": {
+    "logs": {
+      "enabled": false,
+      "invocation_logs": true
+    }
+  },
   "triggers": {
     "crons": ["0 * * * *"]
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,9 @@
   "name": "mlb",
   "compatibility_date": "2025-05-05",
   "compatibility_flags": ["nodejs_compat"],
+  "build": {
+    "command": "node scripts/inject-scheduled.mjs"
+  },
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"


### PR DESCRIPTION
## Summary
- Added `observability` config to wrangler.jsonc so invocation logs persist across deploys
- Added wrangler `build.command` to inject `scheduled()` handler into the OpenNext worker during Cloudflare's git-based deploy

## Test plan
- [ ] Merge and confirm Cloudflare auto-deploys successfully
- [ ] Check that invocation logs appear in Cloudflare dashboard
- [ ] Wait for next hour mark and verify cron trigger fires

https://claude.ai/code/session_016owYtKw83CdXWNqUdMKXTG