### PR TITLE
Enable full observability logging

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,8 +17,9 @@
   },
   "observability": {
     "logs": {
-      "enabled": false,
-      "invocation_logs": true
+      "enabled": true,
+      "invocation_logs": true,
+      "head_sampling_rate": 1
     }
   },
   "triggers": {


### PR DESCRIPTION
## Summary
- Logs were set to `enabled: false`, preventing any cron or worker logs from appearing in Cloudflare dashboard
- Enabled full logging with 100% sampling rate so we can debug the cron trigger

## Test plan
- [ ] Merge and wait for Cloudflare auto-deploy
- [ ] After next hour mark, check Workers Logs for cron invocation

https://claude.ai/code/session_016owYtKw83CdXWNqUdMKXTG