### PR TITLE
Remove video thumbnail from email — potential spoiler

### DIFF
--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -6,7 +6,6 @@ import {
   extractFinalGames,
   fetchGameContent,
   extractHighlightUrl,
-  extractThumbnailUrl,
   getDatesToCheck,
   formatDisplayDate,
 } from "@/lib/mlb";
@@ -55,26 +54,19 @@ export async function GET(request) {
             .single();
 
           if (cached?.highlight_url) {
-            // Already have the highlight — fetch content for thumbnail
-            let thumbnail = null;
-            try {
-              const content = await fetchGameContent(game.gamePk);
-              thumbnail = extractThumbnailUrl(content);
-            } catch (_) {}
+            // Already have the highlight — just need to check for unsent notifications
             newGames.push({
               gamePk: game.gamePk,
               teamId,
               gameDate: dateStr,
               highlightUrl: cached.highlight_url,
-              thumbnailUrl: thumbnail,
             });
             continue;
           }
 
-          // Try to extract highlight URL and thumbnail
+          // Try to extract highlight URL
           const content = await fetchGameContent(game.gamePk);
           const url = extractHighlightUrl(content);
-          const thumbnail = extractThumbnailUrl(content);
 
           // Upsert into game_cache
           await supabase.from("mlb_game_cache").upsert({
@@ -92,7 +84,6 @@ export async function GET(request) {
               teamId,
               gameDate: dateStr,
               highlightUrl: url,
-              thumbnailUrl: thumbnail,
             });
           } else {
             const contentKeys = Object.keys(content || {}).join(", ");
@@ -162,7 +153,7 @@ export async function GET(request) {
       const team = TEAMS_BY_ID[game.teamId];
       const teamName = team?.name || `Team ${game.teamId}`;
       const subject = `${teamName} Highlights \u2014 ${formatDisplayDate(game.gameDate)}`;
-      const html = buildEmailHtml(team, game.highlightUrl, userId, game.gameDate, game.thumbnailUrl);
+      const html = buildEmailHtml(team, game.highlightUrl, userId, game.gameDate);
 
       try {
         await sendEmail(email, subject, html);
@@ -188,7 +179,7 @@ export async function GET(request) {
   });
 }
 
-function buildEmailHtml(team, highlightUrl, userId, gameDate, thumbnailUrl) {
+function buildEmailHtml(team, highlightUrl, userId, gameDate) {
   const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || "https://yourdomain.com";
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
   const teamName = team?.name || "Your team";
@@ -228,23 +219,6 @@ function buildEmailHtml(team, highlightUrl, userId, gameDate, thumbnailUrl) {
     <h1 style="margin:0;font-size:22px;font-weight:700;color:#18181b;line-height:1.3;">${teamName} highlights are ready</h1>
     <p style="margin:8px 0 0 0;font-size:15px;color:#52525b;line-height:1.5;">Your spoiler-free game recap is waiting for you.</p>
   </td></tr>
-
-  <!-- Thumbnail + play button overlay -->
-  ${thumbnailUrl ? `<tr><td style="padding:24px 32px 0 32px;">
-    <a href="${highlightUrl}" style="display:block;text-decoration:none;">
-      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-radius:8px;overflow:hidden;">
-        <tr><td background="${thumbnailUrl}" bgcolor="#18181b" width="100%" height="256" valign="middle" style="background-size:cover;background-position:center;border-radius:8px;">
-          <!--[if gte mso 9]><v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:456px;height:256px;"><v:fill type="frame" src="${thumbnailUrl}"/><v:textbox inset="0,0,0,0"><![endif]-->
-          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" height="256"><tr><td align="center" valign="middle">
-            <div style="width:56px;height:56px;border-radius:50%;background-color:rgba(0,0,0,0.6);line-height:56px;text-align:center;">
-              <span style="font-size:24px;color:#ffffff;margin-left:3px;">&#9654;</span>
-            </div>
-          </td></tr></table>
-          <!--[if gte mso 9]></v:textbox></v:rect><![endif]-->
-        </td></tr>
-      </table>
-    </a>
-  </td></tr>` : ""}
 
   <!-- CTA Button -->
   <tr><td style="padding:24px 32px 0 32px;">

--- a/app/api/test-email/route.js
+++ b/app/api/test-email/route.js
@@ -1,13 +1,6 @@
 import { NextResponse } from "next/server";
 import { TEAMS_BY_ID } from "@/lib/teams";
-import {
-  fetchSchedule,
-  extractFinalGames,
-  fetchGameContent,
-  extractHighlightUrl,
-  extractThumbnailUrl,
-  formatDisplayDate,
-} from "@/lib/mlb";
+import { formatDisplayDate } from "@/lib/mlb";
 
 export async function GET(request) {
   // Only allow with cron secret to prevent abuse
@@ -29,37 +22,10 @@ export async function GET(request) {
 
   const team = TEAMS_BY_ID[teamId];
   const teamName = team?.name || `Team ${teamId}`;
-
-  // Try to find a real recent game for this team to get a real thumbnail
-  let highlightUrl = "https://www.mlb.com/video/search";
-  let thumbnailUrl = null;
-  const now = new Date();
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "America/New_York",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-
-  for (let daysBack = 0; daysBack < 7; daysBack++) {
-    try {
-      const dateStr = formatter.format(new Date(now.getTime() - daysBack * 86400000));
-      const schedule = await fetchSchedule(teamId, dateStr);
-      const finals = extractFinalGames(schedule);
-      if (finals.length > 0) {
-        const content = await fetchGameContent(finals[0].gamePk);
-        const url = extractHighlightUrl(content);
-        const thumb = extractThumbnailUrl(content);
-        if (url) highlightUrl = url;
-        if (thumb) thumbnailUrl = thumb;
-        if (url || thumb) break;
-      }
-    } catch (_) {}
-  }
-
   const gameDate = new Date().toISOString().slice(0, 10);
+  const sampleHighlightUrl = "https://www.mlb.com/video/search";
   const subject = `[TEST] ${teamName} Highlights — ${formatDisplayDate(gameDate)}`;
-  const html = buildTestEmailHtml(team, highlightUrl, "test-user-id", gameDate, thumbnailUrl);
+  const html = buildTestEmailHtml(team, sampleHighlightUrl, "test-user-id", gameDate);
 
   const res = await fetch("https://api.brevo.com/v3/smtp/email", {
     method: "POST",
@@ -84,15 +50,10 @@ export async function GET(request) {
     );
   }
 
-  return NextResponse.json({
-    message: `Test email sent to ${to}`,
-    team: teamName,
-    thumbnailUrl,
-    highlightUrl,
-  });
+  return NextResponse.json({ message: `Test email sent to ${to}`, team: teamName });
 }
 
-function buildTestEmailHtml(team, highlightUrl, userId, gameDate, thumbnailUrl) {
+function buildTestEmailHtml(team, highlightUrl, userId, gameDate) {
   const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || "https://yourdomain.com";
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
   const teamName = team?.name || "Your team";
@@ -132,23 +93,6 @@ function buildTestEmailHtml(team, highlightUrl, userId, gameDate, thumbnailUrl) 
     <h1 style="margin:0;font-size:22px;font-weight:700;color:#18181b;line-height:1.3;">${teamName} highlights are ready</h1>
     <p style="margin:8px 0 0 0;font-size:15px;color:#52525b;line-height:1.5;">Your spoiler-free game recap is waiting for you.</p>
   </td></tr>
-
-  <!-- Thumbnail + play button overlay -->
-  ${thumbnailUrl ? `<tr><td style="padding:24px 32px 0 32px;">
-    <a href="${highlightUrl}" style="display:block;text-decoration:none;">
-      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-radius:8px;overflow:hidden;">
-        <tr><td background="${thumbnailUrl}" bgcolor="#18181b" width="100%" height="256" valign="middle" style="background-size:cover;background-position:center;border-radius:8px;">
-          <!--[if gte mso 9]><v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="width:456px;height:256px;"><v:fill type="frame" src="${thumbnailUrl}"/><v:textbox inset="0,0,0,0"><![endif]-->
-          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" height="256"><tr><td align="center" valign="middle">
-            <div style="width:56px;height:56px;border-radius:50%;background-color:rgba(0,0,0,0.6);line-height:56px;text-align:center;">
-              <span style="font-size:24px;color:#ffffff;margin-left:3px;">&#9654;</span>
-            </div>
-          </td></tr></table>
-          <!--[if gte mso 9]></v:textbox></v:rect><![endif]-->
-        </td></tr>
-      </table>
-    </a>
-  </td></tr>` : ""}
 
   <!-- CTA Button -->
   <tr><td style="padding:24px 32px 0 32px;">

--- a/lib/mlb.js
+++ b/lib/mlb.js
@@ -62,53 +62,6 @@ export function extractHighlightUrl(content) {
   return null;
 }
 
-export function extractThumbnailUrl(content) {
-  // Try legacy highlights path
-  const items = content?.highlights?.highlights?.items;
-  if (items?.length) {
-    const recap = items.find((item) =>
-      item.keywordsAll?.some(
-        (k) => k.value === "game-recap" || k.value === "MLBCOM_GAME_RECAP"
-      )
-    );
-    const thumb = pickThumbnail(recap);
-    if (thumb) return thumb;
-  }
-
-  // Fallback: media.epg
-  const epg = content?.media?.epg;
-  if (Array.isArray(epg)) {
-    for (const title of ["Recap", "Extended Highlights", "Condensed Game"]) {
-      const section = epg.find((e) => e.title === title);
-      const thumb = pickThumbnail(section?.items?.[0]);
-      if (thumb) return thumb;
-    }
-  }
-
-  return null;
-}
-
-function pickThumbnail(item) {
-  if (!item) return null;
-
-  // Check image.cuts (array or object of size variants)
-  const cuts = item.image?.cuts;
-  if (Array.isArray(cuts) && cuts.length) {
-    const wide = cuts.find((c) => c.width >= 480) || cuts[cuts.length - 1];
-    return wide?.src || wide?.url || null;
-  }
-  if (cuts && typeof cuts === "object") {
-    const preferred = cuts["960x540"] || cuts["640x360"] || cuts["480x270"];
-    if (preferred?.src || preferred?.url) return preferred.src || preferred.url;
-    const first = Object.values(cuts)[0];
-    return first?.src || first?.url || null;
-  }
-
-  // Fallback: direct image url
-  if (item.image?.url) return item.image.url;
-
-  return null;
-}
 
 function pickPlaybackUrl(playbacks) {
   if (!Array.isArray(playbacks) || playbacks.length === 0) return null;


### PR DESCRIPTION
A thumbnail showing player celebrations or dejection could reveal the game outcome before the user watches. Keeping the email spoiler-free by removing the thumbnail section entirely.

https://claude.ai/code/session_01TA7GUxhsDHLwK7YCNqGvv4