### PR TITLE
Connect ninthinning.email custom domain

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -5,10 +5,10 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # Brevo (email)
 EMAIL_API_KEY=xkeysib-xxxxx
-FROM_EMAIL=highlights@yourdomain.com
+FROM_EMAIL=highlights@ninthinning.email
 
 # Cron secret (prevents unauthorized access to /api/cron)
 CRON_SECRET=generate-a-random-string-here
 
 # Site URL (for unsubscribe links in emails)
-NEXT_PUBLIC_SITE_URL=https://yourdomain.com
+NEXT_PUBLIC_SITE_URL=https://ninthinning.email

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,8 +12,8 @@
     "binding": "ASSETS"
   },
   "vars": {
-    "SITE_URL": "https://mlb.nmartinovic.workers.dev",
-    "FROM_EMAIL": "info@nickmartinovic.com"
+    "SITE_URL": "https://ninthinning.email",
+    "FROM_EMAIL": "highlights@ninthinning.email"
   },
   "observability": {
     "logs": {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,6 +22,12 @@
       "head_sampling_rate": 1
     }
   },
+  "routes": [
+    {
+      "pattern": "ninthinning.email",
+      "custom_domain": true
+    }
+  ],
   "triggers": {
     "crons": ["0 * * * *"]
   }


### PR DESCRIPTION
## Summary

- Updates `SITE_URL` in `wrangler.jsonc` from `mlb.nmartinovic.workers.dev` to `https://ninthinning.email`
- Updates `FROM_EMAIL` to `highlights@ninthinning.email`
- Adds `routes` entry to `wrangler.jsonc` to declare the custom domain in the Worker config
- Updates `.env.local.example` placeholders to reflect the production domain

## Infrastructure completed (outside this PR)
- Cloudflare DNS active for `ninthinning.email`
- Custom domain added to the `mlb` Worker (TLS provisioned)
- Supabase Site URL + Redirect URLs updated
- Brevo sender domain authenticated, `highlights@ninthinning.email` added as verified sender

## Test plan
- [ ] `https://ninthinning.email` loads with valid HTTPS
- [ ] Magic link login redirects to `https://ninthinning.email/dashboard`
- [ ] Recap email sender shows `highlights@ninthinning.email`
- [ ] Unsubscribe link in email points to `https://ninthinning.email/unsubscribe?token=...`
- [ ] Unsubscribe flow works end-to-end

Closes #53