### PR TITLE
Rebrand to Ninth Inning Email + ballpark palette + step swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Highlight Reel are documented here.
+All notable changes to Ninth Inning Email are documented here.
 
 ## [Unreleased]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Highlight Reel — spoiler-free MLB game recap videos delivered via email. Next.js app deployed on Cloudflare via OpenNext.
+Ninth Inning Email — spoiler-free MLB game recap videos delivered via email. Next.js app deployed on Cloudflare via OpenNext.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Highlight Reel
+# Ninth Inning Email
 
 Spoiler-free MLB game recap videos, delivered to your inbox. No scores, no spoilers — just the highlights.
 

--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -243,16 +243,24 @@ function buildEmailHtml(team, highlightUrl, userId, gameDate) {
     <hr style="margin:0;border:none;border-top:1px solid #e4e4e7;">
   </td></tr>
 
+  ${tipUrl ? `
+  <!-- Tip prompt -->
+  <tr><td align="center" style="padding:18px 32px 0 32px;">
+    <p style="margin:0;font-size:13px;color:#52525b;line-height:1.5;">
+      Enjoying Ninth Inning Email? <a href="${tipUrl}" style="color:${teamColor};text-decoration:underline;font-weight:600;">Tip the developer</a> to keep it running.
+    </p>
+  </td></tr>
+  ` : ""}
+
   <!-- Footer -->
   <tr><td style="padding:16px 32px 0 32px;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td style="font-size:13px;color:#a1a1aa;">
-          <strong style="color:#52525b;">Highlight Reel</strong><br>
+          <strong style="color:#52525b;">Ninth Inning Email</strong><br>
           Spoiler-free MLB recaps
         </td>
         <td align="right" style="font-size:12px;vertical-align:top;">
-          ${tipUrl ? `<a href="${tipUrl}" style="color:#a1a1aa;text-decoration:underline;">Support this project</a><br>` : ""}
           <a href="${unsubscribeUrl}" style="color:#a1a1aa;text-decoration:underline;">Unsubscribe</a>
         </td>
       </tr>
@@ -261,7 +269,7 @@ function buildEmailHtml(team, highlightUrl, userId, gameDate) {
 
   <!-- Disclaimer -->
   <tr><td style="padding:12px 32px 28px 32px;">
-    <p style="margin:0;font-size:11px;color:#a1a1aa;line-height:1.5;">Highlight Reel is not affiliated with, endorsed by, or sponsored by MLB or any MLB club. Questions or takedown requests: <a href="mailto:abuse@ninthinning.email" style="color:#a1a1aa;">abuse@ninthinning.email</a></p>
+    <p style="margin:0;font-size:11px;color:#a1a1aa;line-height:1.5;">Ninth Inning Email is not affiliated with, endorsed by, or sponsored by MLB or any MLB club. Questions or takedown requests: <a href="mailto:abuse@ninthinning.email" style="color:#a1a1aa;">abuse@ninthinning.email</a></p>
   </td></tr>
 
 </table>

--- a/app/api/test-email/route.js
+++ b/app/api/test-email/route.js
@@ -113,7 +113,7 @@ function buildTestEmailHtml(team, highlightUrl, userId, gameDate) {
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
       <tr>
         <td style="font-size:13px;color:#a1a1aa;">
-          <strong style="color:#52525b;">Highlight Reel</strong><br>
+          <strong style="color:#52525b;">Ninth Inning Email</strong><br>
           Spoiler-free MLB recaps
         </td>
         <td align="right" style="font-size:12px;">

--- a/app/layout.js
+++ b/app/layout.js
@@ -3,24 +3,24 @@ import "./globals.css";
 export const metadata = {
   metadataBase: new URL(process.env.SITE_URL || "https://ninthinning.email"),
   title: {
-    default: "Highlight Reel — Spoiler-free MLB recaps in your inbox",
-    template: "%s · Highlight Reel",
+    default: "Ninth Inning Email — Spoiler-free MLB recaps in your inbox",
+    template: "%s · Ninth Inning Email",
   },
   description:
     "Spoiler-free MLB game recap videos delivered to your inbox the morning after. No scores, no spoilers — just the highlights.",
   keywords: ["MLB", "baseball", "highlights", "spoiler-free", "recap", "email"],
   alternates: { canonical: "/" },
   openGraph: {
-    title: "Highlight Reel — Spoiler-free MLB recaps",
+    title: "Ninth Inning Email — Spoiler-free MLB recaps",
     description:
       "Pick your teams. We email the recap. No scores, no spoilers.",
     url: "/",
-    siteName: "Highlight Reel",
+    siteName: "Ninth Inning Email",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Highlight Reel — Spoiler-free MLB recaps",
+    title: "Ninth Inning Email — Spoiler-free MLB recaps",
     description:
       "Pick your teams. We email the recap. No scores, no spoilers.",
   },
@@ -29,7 +29,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gray-950 text-gray-100 antialiased">
+      <body className="min-h-screen bg-[#0a1410] text-[#f5f1e6] antialiased">
         {children}
       </body>
     </html>

--- a/app/opengraph-image.js
+++ b/app/opengraph-image.js
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 
-export const alt = "Highlight Reel — Spoiler-free MLB recaps in your inbox";
+export const alt =
+  "Ninth Inning Email — Spoiler-free MLB recaps in your inbox";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -17,8 +18,8 @@ export default async function OpengraphImage() {
           alignItems: "flex-start",
           padding: "80px",
           background:
-            "radial-gradient(ellipse 80% 60% at 30% 0%, #1e3a8a 0%, #030712 60%)",
-          color: "#f3f4f6",
+            "radial-gradient(ellipse 80% 60% at 30% 0%, #0f5132 0%, #0a1410 60%)",
+          color: "#f5f1e6",
           fontFamily: "system-ui, -apple-system, sans-serif",
         }}
       >
@@ -29,7 +30,7 @@ export default async function OpengraphImage() {
             gap: "16px",
             fontSize: "28px",
             fontWeight: 600,
-            color: "#9ca3af",
+            color: "#a8a299",
             letterSpacing: "0.02em",
           }}
         >
@@ -39,7 +40,7 @@ export default async function OpengraphImage() {
                 width: 18,
                 height: 18,
                 borderRadius: 999,
-                background: "#005A9C",
+                background: "#c41e3a",
               }}
             />
             <div
@@ -47,7 +48,7 @@ export default async function OpengraphImage() {
                 width: 18,
                 height: 18,
                 borderRadius: 999,
-                background: "#E81828",
+                background: "#f5f1e6",
               }}
             />
             <div
@@ -55,11 +56,11 @@ export default async function OpengraphImage() {
                 width: 18,
                 height: 18,
                 borderRadius: 999,
-                background: "#FFC52F",
+                background: "#c41e3a",
               }}
             />
           </div>
-          <span>Highlight Reel</span>
+          <span>Ninth Inning Email</span>
         </div>
         <div
           style={{
@@ -68,7 +69,7 @@ export default async function OpengraphImage() {
             fontWeight: 800,
             lineHeight: 1.05,
             letterSpacing: "-0.03em",
-            color: "#f9fafb",
+            color: "#f5f1e6",
             maxWidth: "1000px",
           }}
         >
@@ -78,7 +79,7 @@ export default async function OpengraphImage() {
           style={{
             marginTop: "32px",
             fontSize: "32px",
-            color: "#9ca3af",
+            color: "#a8a299",
             maxWidth: "900px",
           }}
         >

--- a/app/page.js
+++ b/app/page.js
@@ -18,7 +18,7 @@ function EmailPreview({ size = "sm" }) {
       }`}
     >
       <div className="mb-2 flex items-center justify-center">
-        <span className="rounded-full border border-gray-700 bg-gray-900/60 px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-gray-400">
+        <span className="rounded-full border border-[#1f3a2c] bg-[#0f2a1f]/60 px-3 py-1 text-[11px] font-medium uppercase tracking-wider text-[#a8a299]">
           Preview
         </span>
       </div>
@@ -56,7 +56,7 @@ function EmailPreview({ size = "sm" }) {
         <div className="border-t border-gray-200 px-6 py-4 sm:px-8">
           <div className="flex items-center justify-between text-xs text-gray-500">
             <div>
-              <strong className="text-gray-700">Highlight Reel</strong>
+              <strong className="text-gray-700">Ninth Inning Email</strong>
               <div>Spoiler-free MLB recaps</div>
             </div>
             <span className="underline">Unsubscribe</span>
@@ -69,12 +69,12 @@ function EmailPreview({ size = "sm" }) {
 
 function StepCard({ n, title, body }) {
   return (
-    <div className="rounded-2xl border border-gray-800 bg-gray-900/40 p-6">
-      <div className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-700 text-sm font-semibold text-gray-300">
+    <div className="rounded-2xl border border-[#1f3a2c] bg-[#0f2a1f]/40 p-6">
+      <div className="flex h-9 w-9 items-center justify-center rounded-full border border-[#2d5240] text-sm font-semibold text-[#f5f1e6]">
         {n}
       </div>
-      <h3 className="mt-4 text-base font-semibold text-gray-100">{title}</h3>
-      <p className="mt-2 text-sm text-gray-400">{body}</p>
+      <h3 className="mt-4 text-base font-semibold text-[#f5f1e6]">{title}</h3>
+      <p className="mt-2 text-sm text-[#a8a299]">{body}</p>
     </div>
   );
 }
@@ -82,24 +82,24 @@ function StepCard({ n, title, body }) {
 function Stat({ value, label }) {
   return (
     <div className="text-center sm:text-left">
-      <div className="text-3xl font-bold text-gray-100 sm:text-4xl">
+      <div className="text-3xl font-bold text-[#f5f1e6] sm:text-4xl">
         {value}
       </div>
-      <div className="mt-1 text-sm text-gray-400">{label}</div>
+      <div className="mt-1 text-sm text-[#a8a299]">{label}</div>
     </div>
   );
 }
 
 function FaqItem({ q, children }) {
   return (
-    <details className="group rounded-xl border border-gray-800 bg-gray-900/40 px-5 py-4 open:bg-gray-900/60">
-      <summary className="flex cursor-pointer items-center justify-between text-sm font-medium text-gray-200 list-none [&::-webkit-details-marker]:hidden">
+    <details className="group rounded-xl border border-[#1f3a2c] bg-[#0f2a1f]/40 px-5 py-4 open:bg-[#0f2a1f]/60">
+      <summary className="flex cursor-pointer items-center justify-between text-sm font-medium text-[#f5f1e6] list-none [&::-webkit-details-marker]:hidden">
         <span>{q}</span>
-        <span className="ml-4 text-gray-500 transition-transform group-open:rotate-45">
+        <span className="ml-4 text-[#a8a299] transition-transform group-open:rotate-45">
           +
         </span>
       </summary>
-      <div className="mt-3 text-sm leading-relaxed text-gray-400">
+      <div className="mt-3 text-sm leading-relaxed text-[#a8a299]">
         {children}
       </div>
     </details>
@@ -113,12 +113,12 @@ export default function Home() {
     <div className="min-h-screen">
       {/* Top bar */}
       <header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
-        <span className="text-sm font-semibold tracking-tight text-gray-200">
-          Highlight Reel
+        <span className="text-sm font-semibold tracking-tight text-[#f5f1e6]">
+          Ninth Inning Email
         </span>
         <Link
           href="/login"
-          className="text-sm font-medium text-gray-400 hover:text-gray-200 transition"
+          className="text-sm font-medium text-[#a8a299] hover:text-[#f5f1e6] transition"
         >
           Sign in
         </Link>
@@ -127,41 +127,41 @@ export default function Home() {
       {/* Hero */}
       <section className="relative overflow-hidden">
         <div
-          className="pointer-events-none absolute inset-0 -z-10 opacity-60"
+          className="pointer-events-none absolute inset-0 -z-10 opacity-70"
           style={{
             background:
-              "radial-gradient(ellipse 80% 50% at 50% -10%, rgba(37,99,235,0.25), transparent 70%)",
+              "radial-gradient(ellipse 80% 50% at 50% -10%, rgba(15,81,50,0.45), transparent 70%)",
           }}
           aria-hidden="true"
         />
         <div className="mx-auto max-w-6xl px-6 pb-20 pt-10 sm:pt-16 lg:pt-24">
           <div className="grid items-center gap-12 lg:grid-cols-2">
             <div className="text-center lg:text-left">
-              <span className="inline-block rounded-full border border-gray-800 bg-gray-900/60 px-3 py-1 text-xs font-medium text-gray-400">
+              <span className="inline-block rounded-full border border-[#1f3a2c] bg-[#0f2a1f]/60 px-3 py-1 text-xs font-medium text-[#a8a299]">
                 Free · For MLB fans
               </span>
-              <h1 className="mt-5 text-4xl font-bold tracking-tight text-gray-50 sm:text-5xl lg:text-6xl">
+              <h1 className="mt-5 text-4xl font-bold tracking-tight text-[#f5f1e6] sm:text-5xl lg:text-6xl">
                 Spoiler-free MLB recaps in your inbox.
               </h1>
-              <p className="mt-5 text-lg text-gray-400 sm:text-xl">
+              <p className="mt-5 text-lg text-[#a8a299] sm:text-xl">
                 Pick your teams. We email the recap the next morning. No
                 scores, no spoilers — just the highlights.
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center lg:justify-start">
                 <Link
                   href="/login"
-                  className="rounded-lg bg-blue-600 px-6 py-3 text-sm font-semibold text-white hover:bg-blue-500 transition"
+                  className="rounded-lg bg-[#c41e3a] px-6 py-3 text-sm font-semibold text-white hover:bg-[#d92645] transition"
                 >
                   Get my recaps
                 </Link>
                 <a
                   href="#sample"
-                  className="rounded-lg border border-gray-700 px-6 py-3 text-sm font-semibold text-gray-300 hover:border-gray-500 transition"
+                  className="rounded-lg border border-[#2d5240] px-6 py-3 text-sm font-semibold text-[#f5f1e6] hover:border-[#3f6e57] transition"
                 >
                   See a sample email
                 </a>
               </div>
-              <p className="mt-4 text-xs text-gray-500">
+              <p className="mt-4 text-xs text-[#a8a299]">
                 Free · No ads · Unsubscribe anytime
               </p>
             </div>
@@ -173,7 +173,7 @@ export default function Home() {
       </section>
 
       {/* Stat strip */}
-      <section className="border-y border-gray-900 bg-gray-950/60">
+      <section className="border-y border-[#1f3a2c] bg-[#0a1410]/60">
         <div className="mx-auto grid max-w-6xl grid-cols-1 gap-8 px-6 py-10 sm:grid-cols-3">
           <Stat value="30" label="MLB teams supported" />
           <Stat value="0" label="Scores spoiled" />
@@ -184,10 +184,10 @@ export default function Home() {
       {/* How it works */}
       <section className="mx-auto max-w-6xl px-6 py-20">
         <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-100 sm:text-4xl">
+          <h2 className="text-3xl font-bold tracking-tight text-[#f5f1e6] sm:text-4xl">
             How it works
           </h2>
-          <p className="mt-3 text-gray-400">
+          <p className="mt-3 text-[#a8a299]">
             Three steps. No app to install. No score in sight.
           </p>
         </div>
@@ -199,25 +199,25 @@ export default function Home() {
           />
           <StepCard
             n="2"
-            title="Watch the game (or don't)"
-            body="After the game ends, we find the recap video automatically."
+            title="Check your inbox"
+            body="The morning after the game, a spoiler-free email lands in your inbox with a direct link to the recap."
           />
           <StepCard
             n="3"
-            title="Check your inbox"
-            body="A spoiler-free email with a direct link to the 3–5 minute game highlights. No scores, no outcomes."
+            title="Watch the game (or don't)"
+            body="3–5 minutes of highlights from MLB.com. No scores in the subject line, no spoilers in the email."
           />
         </div>
       </section>
 
       {/* Sample email */}
-      <section id="sample" className="border-t border-gray-900 bg-gray-950/60">
+      <section id="sample" className="border-t border-[#1f3a2c] bg-[#0a1410]/60">
         <div className="mx-auto max-w-4xl px-6 py-20">
           <div className="mx-auto max-w-2xl text-center">
-            <h2 className="text-3xl font-bold tracking-tight text-gray-100 sm:text-4xl">
+            <h2 className="text-3xl font-bold tracking-tight text-[#f5f1e6] sm:text-4xl">
               Here's what lands in your inbox
             </h2>
-            <p className="mt-3 text-gray-400">
+            <p className="mt-3 text-[#a8a299]">
               Just the link. No score, no spoiler, no clickbait.
             </p>
           </div>
@@ -229,14 +229,14 @@ export default function Home() {
 
       {/* Built by a fan */}
       <section className="mx-auto max-w-3xl px-6 py-20 text-center">
-        <h2 className="text-2xl font-bold tracking-tight text-gray-100 sm:text-3xl">
+        <h2 className="text-2xl font-bold tracking-tight text-[#f5f1e6] sm:text-3xl">
           Built by a fan, for fans
         </h2>
-        <p className="mt-5 text-gray-400">
-          I built Highlight Reel because I kept getting scores spoiled before I
-          could watch the recap — push notifications, group chats, the home
-          page of every sports site. So I made the email I wanted: one link,
-          no score, no fuss.
+        <p className="mt-5 text-[#a8a299]">
+          I built Ninth Inning Email because I kept getting scores spoiled
+          before I could watch the recap — push notifications, group chats,
+          the home page of every sports site. So I made the email I wanted:
+          one link, no score, no fuss.
         </p>
         {tipUrl && (
           <p className="mt-6 text-sm">
@@ -244,9 +244,9 @@ export default function Home() {
               href={tipUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-gray-400 underline hover:text-gray-200 transition"
+              className="inline-block rounded-lg border border-[#2d5240] px-5 py-2 font-semibold text-[#f5f1e6] hover:border-[#c41e3a] hover:text-[#c41e3a] transition"
             >
-              Support this project
+              Tip the developer
             </a>
           </p>
         )}
@@ -254,13 +254,13 @@ export default function Home() {
 
       {/* FAQ */}
       <section className="mx-auto max-w-3xl px-6 pb-20">
-        <h2 className="text-center text-2xl font-bold tracking-tight text-gray-100 sm:text-3xl">
+        <h2 className="text-center text-2xl font-bold tracking-tight text-[#f5f1e6] sm:text-3xl">
           Questions
         </h2>
         <div className="mt-8 space-y-3">
           <FaqItem q="Is it free?">
-            Yes. Highlight Reel is free for personal use. There's a tip link
-            if you want to chip in for hosting, but nothing is gated.
+            Yes. Ninth Inning Email is free for personal use. There's a tip
+            link if you want to chip in for hosting, but nothing is gated.
           </FaqItem>
           <FaqItem q="Will I see the score by accident?">
             No. The email subject and body are written to be spoiler-free —
@@ -276,18 +276,18 @@ export default function Home() {
 
       {/* Final CTA */}
       <section className="mx-auto max-w-6xl px-6 pb-24">
-        <div className="rounded-3xl border border-gray-800 bg-gradient-to-br from-blue-600/10 to-gray-900/40 px-6 py-14 text-center sm:px-12">
-          <h2 className="text-3xl font-bold tracking-tight text-gray-50 sm:text-4xl">
+        <div className="rounded-3xl border border-[#1f3a2c] bg-gradient-to-br from-[#0f5132]/20 to-[#0f2a1f]/40 px-6 py-14 text-center sm:px-12">
+          <h2 className="text-3xl font-bold tracking-tight text-[#f5f1e6] sm:text-4xl">
             Ready for spoiler-free recaps?
           </h2>
-          <p className="mx-auto mt-4 max-w-xl text-gray-400">
+          <p className="mx-auto mt-4 max-w-xl text-[#a8a299]">
             Sign in with a magic link, pick your teams, and we'll handle the
             rest.
           </p>
           <div className="mt-8 flex justify-center">
             <Link
               href="/login"
-              className="rounded-lg bg-blue-600 px-8 py-3.5 text-sm font-semibold text-white hover:bg-blue-500 transition"
+              className="rounded-lg bg-[#c41e3a] px-8 py-3.5 text-sm font-semibold text-white hover:bg-[#d92645] transition"
             >
               Get my recaps
             </Link>
@@ -296,19 +296,19 @@ export default function Home() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-gray-900">
-        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 py-8 text-xs text-gray-500 sm:flex-row">
+      <footer className="border-t border-[#1f3a2c]">
+        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 py-8 text-xs text-[#a8a299] sm:flex-row">
           <p className="text-center sm:text-left">
-            Highlight Reel is not affiliated with, endorsed by, or sponsored
-            by MLB or any MLB club. Video links courtesy of MLB.com.
+            Ninth Inning Email is not affiliated with, endorsed by, or
+            sponsored by MLB or any MLB club. Video links courtesy of MLB.com.
           </p>
           <div className="flex items-center gap-5">
-            <Link href="/login" className="hover:text-gray-300 transition">
+            <Link href="/login" className="hover:text-[#f5f1e6] transition">
               Sign in
             </Link>
             <Link
               href="/unsubscribe"
-              className="hover:text-gray-300 transition"
+              className="hover:text-[#f5f1e6] transition"
             >
               Unsubscribe
             </Link>

--- a/public/architecture.html
+++ b/public/architecture.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Highlight Reel — Architecture</title>
+<title>Ninth Inning Email — Architecture</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
@@ -39,7 +39,7 @@
   </defs>
 
   <!-- Title -->
-  <text x="550" y="42" text-anchor="middle" fill="#f1f5f9" font-size="26" font-weight="700" letter-spacing="1">Highlight Reel</text>
+  <text x="550" y="42" text-anchor="middle" fill="#f1f5f9" font-size="26" font-weight="700" letter-spacing="1">Ninth Inning Email</text>
   <text x="550" y="66" text-anchor="middle" fill="#64748b" font-size="14">Spoiler-free MLB game recaps, delivered to your inbox</text>
 
   <!-- ===== FLOW LABELS ===== -->


### PR DESCRIPTION
Follow-up to #16 polish.

## Summary
- Rebrand: "Highlight Reel" → "Ninth Inning Email" across landing page, layout metadata, OG image, both email templates, README, CLAUDE.md, CHANGELOG, and `public/architecture.html`.
- Palette: ballpark theme — field green (`#0f5132` / `#0f2a1f`) surfaces, cream (`#f5f1e6`) text, stitching-red (`#c41e3a`) CTAs, near-black green-tinted (`#0a1410`) background. Replaces the tech-blue gradient.
- How it works: swapped steps 2 and 3 so the order reads pick teams → check inbox → watch (or don't); copy rebalanced for the new flow.
- Tip link: promoted in cron emails to its own centered row above the footer ("Enjoying Ninth Inning Email? Tip the developer to keep it running.") instead of a small text link. Still gated on `TIP_URL` env var.

## Out of scope (filed separately)
- Hiding the tip link in emails once a user has tipped → #59 (needs Stripe webhook + DB column).

## Test plan
- [x] `npm run build` — green; all routes including `/opengraph-image` build successfully
- [ ] `npm run dev` and visually QA at 375px / 768px / 1280px — confirm hero stacks, no horizontal scroll, palette reads correctly
- [ ] Verify `/opengraph-image` renders the new green/cream/red card
- [ ] Send a test email via `/api/test-email?to=...` and confirm the new tip-prompt row appears in the rendered HTML (or doesn't, if `TIP_URL` is unset locally)
- [ ] Confirm "How it works" reads in the new order
- [ ] After deploy: `https://ninthinning.email` shows the rebrand and palette

https://claude.ai/code/session_01XUhFTk1BZJQygqbdidDqkN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUhFTk1BZJQygqbdidDqkN)_