### PR TITLE
Restore TIP_URL in wrangler.jsonc to fix missing tip block in emails

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -16,5 +16,6 @@ NEXT_PUBLIC_SITE_URL=https://ninthinning.email
 # Kill switch: set to "true" to immediately pause all cron email sends (no redeploy needed)
 EMAILS_PAUSED=
 
-# Stripe Payment Link for the tip jar — fill in after creating your Payment Link
+# Stripe Payment Link for the tip jar — production value lives in wrangler.jsonc;
+# set this for local dev if you want the tip block to render.
 TIP_URL=https://buy.stripe.com/YOUR_PAYMENT_LINK

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,8 @@
   },
   "vars": {
     "SITE_URL": "https://ninthinning.email",
-    "FROM_EMAIL": "highlights@ninthinning.email"
+    "FROM_EMAIL": "highlights@ninthinning.email",
+    "TIP_URL": "https://buy.stripe.com/28E3cv4w0aDs2yVg16dZ600"
   },
   "observability": {
     "logs": {

--- a/wrangler.test.js
+++ b/wrangler.test.js
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const wranglerPath = fileURLToPath(new URL("./wrangler.jsonc", import.meta.url));
+
+function parseJsonc(text) {
+  const stripped = text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:"])\/\/.*$/gm, "$1");
+  return JSON.parse(stripped);
+}
+
+describe("wrangler.jsonc", () => {
+  const config = parseJsonc(readFileSync(wranglerPath, "utf8"));
+
+  it("defines TIP_URL so the tip block renders in production emails", () => {
+    expect(config.vars?.TIP_URL).toMatch(/^https:\/\/buy\.stripe\.com\//);
+  });
+
+  it("keeps SITE_URL and FROM_EMAIL pointed at ninthinning.email", () => {
+    expect(config.vars?.SITE_URL).toBe("https://ninthinning.email");
+    expect(config.vars?.FROM_EMAIL).toBe("highlights@ninthinning.email");
+  });
+});


### PR DESCRIPTION
Closes #65. Does not affect #59.

## Summary

The "Tip the developer" row stopped rendering in cron recap emails (e.g. the April 27, 2026 Mariners email). Root cause: PR #57 removed `TIP_URL` from `wrangler.jsonc` on the assumption it would live as a Cloudflare Worker secret, but that secret was never set (or was wiped by a later deploy). `process.env.TIP_URL` is therefore undefined in the running worker, so the conditional in `lib/email-template.js` silently drops the block. Same gating exists on the landing page (`app/page.js:110`), so this fix restores both.

The Stripe Payment Link URL is not sensitive — it ships in every email and on the public landing page — so source-controlling it as a plain `vars` entry is simpler than dashboard/secret management and immune to deploy-time wipes.

## Changes

- `wrangler.jsonc`: re-add `TIP_URL` with the production Stripe Payment Link.
- `.env.local.example`: clarify the production value lives in `wrangler.jsonc`; the example here is for local dev only.
- `wrangler.test.js` (new): two assertions so CI catches a future re-removal — `TIP_URL` must match `https://buy.stripe.com/…`, and `SITE_URL`/`FROM_EMAIL` stay pointed at `ninthinning.email`.

## Test plan

- [x] `npm run test` — 36/36 passing (34 prior + 2 new in `wrangler.test.js`)
- [x] `npm run build` — clean
- [ ] After deploy, send a test email via `/api/test-email?to=…` and confirm the "Enjoying Ninth Inning Email? Tip the developer to keep it running." row appears above the footer
- [ ] After deploy, spot-check `https://ninthinning.email` to confirm the FAQ tip link is back

## Relationship to #59

#59 is the future feature of hiding the tip link **after** a user has tipped (Stripe webhook + DB plumbing). This PR fixes the regression where the link is missing for **everyone**. Once #59 lands, the conditional becomes `tipUrl && !hasTipped` instead of just `tipUrl` — no conflict.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEy4PzpwX21ZD3iX2brxyC)_