### PR TITLE
Set Brevo sender display name to "Ninth Inning Email"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Ninth Inning Email are documented here.
 
 ## [Unreleased]
 
+### Changed
+- Brevo `sender` now includes a friendly display name ("Ninth Inning Email") in `app/api/cron/route.js` and `app/api/test-email/route.js`, so inboxes show the brand instead of the raw `highlights@ninthinning.email` address (closes #19)
+
 ## [2026-04-28]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ npm run deploy     # Deploy to Cloudflare
 
 - **URL**: https://ninthinning.email
 - **Cloudflare Worker**: `mlb` (custom domain declared in `wrangler.jsonc` under `routes`)
-- **Email sender**: `highlights@ninthinning.email` (Brevo, domain authenticated)
+- **Email sender**: `Ninth Inning Email <highlights@ninthinning.email>` (Brevo, domain authenticated; display name set in `app/api/cron/route.js` and `app/api/test-email/route.js`)
 - **Supabase auth redirect**: `https://ninthinning.email/auth/callback`
 - `SITE_URL` and `FROM_EMAIL` are set as vars in `wrangler.jsonc`; secrets (Supabase keys, `EMAIL_API_KEY`, `CRON_SECRET`) are stored as Cloudflare Worker secrets via Wrangler
 

--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -194,7 +194,7 @@ async function sendEmail(to, subject, html) {
       Accept: "application/json",
     },
     body: JSON.stringify({
-      sender: { email: process.env.FROM_EMAIL },
+      sender: { email: process.env.FROM_EMAIL, name: "Ninth Inning Email" },
       to: [{ email: to }],
       subject,
       htmlContent: html,

--- a/app/api/test-email/route.js
+++ b/app/api/test-email/route.js
@@ -35,7 +35,7 @@ export async function GET(request) {
       Accept: "application/json",
     },
     body: JSON.stringify({
-      sender: { email: process.env.FROM_EMAIL },
+      sender: { email: process.env.FROM_EMAIL, name: "Ninth Inning Email" },
       to: [{ email: to }],
       subject,
       htmlContent: html,


### PR DESCRIPTION
## Summary

- Adds a `name` to the Brevo `sender` object in both `app/api/cron/route.js:197` and `app/api/test-email/route.js:38`, so recipients see "Ninth Inning Email" instead of the raw `highlights@ninthinning.email` address. Friendly sender names typically lift open rates and look less like transactional spam.
- Documents the change under `[Unreleased]` in `CHANGELOG.md` and updates the production email-sender note in `CLAUDE.md` to reflect the new display.

Closes #19.

## Test plan

- [x] `npm test` (5 files, 36 tests passing)
- [ ] After deploy: send a test via `/api/test-email` and confirm Gmail / Apple Mail show "Ninth Inning Email" as the sender name
- [ ] Confirm next scheduled cron email also lands with the friendly sender

https://claude.ai/code/session_01TQDJWmZjWavmA3eggMkwMo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQDJWmZjWavmA3eggMkwMo)_