### PR TITLE
Extract Brevo sendEmail helper + regression test for sender name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Ninth Inning Email are documented here.
 
 ### Changed
 - Brevo `sender` now includes a friendly display name ("Ninth Inning Email") in `app/api/cron/route.js` and `app/api/test-email/route.js`, so inboxes show the brand instead of the raw `highlights@ninthinning.email` address (closes #19)
+- Extracted the Brevo transactional call into `lib/brevo.js` (`sendEmail` + `SENDER_NAME`); cron and test-email routes now share one implementation, and the helper accepts an injectable `fetchImpl` so it can be unit-tested without hitting Brevo
+
+### Added
+- `lib/brevo.test.js` covering request shape (endpoint, headers, body), `sender.name`, `sender.email`, recipient/subject/html forwarding, and the non-2xx error path — locks in the sender display name as a regression test
 
 ## [2026-04-28]
 

--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -10,6 +10,7 @@ import {
   formatDisplayDate,
 } from "@/lib/mlb";
 import { buildEmailHtml } from "@/lib/email-template";
+import { sendEmail } from "@/lib/brevo";
 
 export const maxDuration = 60;
 
@@ -183,26 +184,4 @@ export async function GET(request) {
     errors: errors.length > 0 ? errors : undefined,
     skipped: skipped.length > 0 ? skipped : undefined,
   });
-}
-
-async function sendEmail(to, subject, html) {
-  const res = await fetch("https://api.brevo.com/v3/smtp/email", {
-    method: "POST",
-    headers: {
-      "api-key": process.env.EMAIL_API_KEY,
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      sender: { email: process.env.FROM_EMAIL, name: "Ninth Inning Email" },
-      to: [{ email: to }],
-      subject,
-      htmlContent: html,
-    }),
-  });
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    throw new Error(`Brevo ${res.status}: ${body.slice(0, 200)}`);
-  }
 }

--- a/app/api/test-email/route.js
+++ b/app/api/test-email/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { TEAMS_BY_ID } from "@/lib/teams";
 import { formatDisplayDate } from "@/lib/mlb";
+import { sendEmail } from "@/lib/brevo";
 
 export async function GET(request) {
   // Only allow with cron secret to prevent abuse
@@ -27,27 +28,10 @@ export async function GET(request) {
   const subject = `[TEST] ${teamName} Highlights — ${formatDisplayDate(gameDate)}`;
   const html = buildTestEmailHtml(team, sampleHighlightUrl, "test-user-id", gameDate);
 
-  const res = await fetch("https://api.brevo.com/v3/smtp/email", {
-    method: "POST",
-    headers: {
-      "api-key": process.env.EMAIL_API_KEY,
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      sender: { email: process.env.FROM_EMAIL, name: "Ninth Inning Email" },
-      to: [{ email: to }],
-      subject,
-      htmlContent: html,
-    }),
-  });
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => "");
-    return NextResponse.json(
-      { error: `Brevo ${res.status}: ${body.slice(0, 300)}` },
-      { status: 500 }
-    );
+  try {
+    await sendEmail(to, subject, html);
+  } catch (err) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
   }
 
   return NextResponse.json({ message: `Test email sent to ${to}`, team: teamName });

--- a/lib/brevo.js
+++ b/lib/brevo.js
@@ -1,0 +1,26 @@
+export const SENDER_NAME = "Ninth Inning Email";
+const BREVO_ENDPOINT = "https://api.brevo.com/v3/smtp/email";
+
+export async function sendEmail(to, subject, html, { fetchImpl = fetch } = {}) {
+  const res = await fetchImpl(BREVO_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "api-key": process.env.EMAIL_API_KEY,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      sender: { email: process.env.FROM_EMAIL, name: SENDER_NAME },
+      to: [{ email: to }],
+      subject,
+      htmlContent: html,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Brevo ${res.status}: ${body.slice(0, 200)}`);
+  }
+
+  return res;
+}

--- a/lib/brevo.test.js
+++ b/lib/brevo.test.js
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendEmail, SENDER_NAME } from "./brevo";
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env.EMAIL_API_KEY = "test-api-key";
+  process.env.FROM_EMAIL = "highlights@ninthinning.email";
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+function makeFetchStub({ ok = true, status = 200, text = "" } = {}) {
+  return vi.fn(async () => ({
+    ok,
+    status,
+    text: async () => text,
+  }));
+}
+
+describe("sendEmail", () => {
+  it("posts to the Brevo transactional endpoint", async () => {
+    const fetchImpl = makeFetchStub();
+    await sendEmail("user@example.com", "subject", "<p>body</p>", { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe("https://api.brevo.com/v3/smtp/email");
+    expect(init.method).toBe("POST");
+    expect(init.headers["api-key"]).toBe("test-api-key");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it('sets sender.name to "Ninth Inning Email" so inboxes show the brand', async () => {
+    const fetchImpl = makeFetchStub();
+    await sendEmail("user@example.com", "subject", "<p>body</p>", { fetchImpl });
+
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.sender.name).toBe("Ninth Inning Email");
+    expect(body.sender.name).toBe(SENDER_NAME);
+  });
+
+  it("uses FROM_EMAIL env var as the sender address", async () => {
+    const fetchImpl = makeFetchStub();
+    await sendEmail("user@example.com", "subject", "<p>body</p>", { fetchImpl });
+
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.sender.email).toBe("highlights@ninthinning.email");
+  });
+
+  it("forwards recipient, subject, and html into the request body", async () => {
+    const fetchImpl = makeFetchStub();
+    await sendEmail("fan@example.com", "Yankees Highlights", "<p>watch</p>", {
+      fetchImpl,
+    });
+
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.to).toEqual([{ email: "fan@example.com" }]);
+    expect(body.subject).toBe("Yankees Highlights");
+    expect(body.htmlContent).toBe("<p>watch</p>");
+  });
+
+  it("throws with the Brevo status and body excerpt on non-2xx", async () => {
+    const fetchImpl = makeFetchStub({
+      ok: false,
+      status: 401,
+      text: "invalid api key",
+    });
+
+    await expect(
+      sendEmail("user@example.com", "subject", "<p>body</p>", { fetchImpl })
+    ).rejects.toThrow("Brevo 401: invalid api key");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to merged PR #71 (which only landed the bare `name: "Ninth Inning Email"` config change). This PR adds the regression test that locks in the sender display name so a future edit can't silently revert it without failing CI.

- New `lib/brevo.js` exporting `sendEmail(to, subject, html, { fetchImpl })` and a `SENDER_NAME` constant. Both routes now call this single helper instead of duplicating the Brevo `fetch` block.
- `app/api/cron/route.js` and `app/api/test-email/route.js` updated to import from `lib/brevo`. The duplicated inline Brevo call (and its non-2xx error handling) is removed.
- New `lib/brevo.test.js` with 5 tests covering: endpoint + headers, `sender.name === "Ninth Inning Email"`, `sender.email === FROM_EMAIL`, recipient/subject/html forwarding, and the non-2xx error path.
- CHANGELOG `[Unreleased]` entry expanded to mention the refactor + new tests.

End-to-end inbox verification (Gmail "via brevo.com" suffix, DKIM downgrades, etc.) is **not** in scope for this PR — it's tracked in #72.

## Test plan

- [x] `npm test` — 6 files, 41 tests passing (was 36)
- [x] Cron and test-email routes still import the same `sendEmail` signature; no behavior change
- [ ] After deploy: confirm next scheduled cron email lands with the friendly sender (same manual check as #71)

Refs #19, #72.

https://claude.ai/code/session_01TQDJWmZjWavmA3eggMkwMo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQDJWmZjWavmA3eggMkwMo)_