### PR TITLE
Audit secrets handling and add gitleaks to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,16 @@ jobs:
 
       - run: npm ci
       - run: npm test
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so gitleaks can scan every commit, not just the PR head.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,19 @@
 node_modules/
 .next/
 .open-next/
-.env.local
-.env*.local
+
+# Environment files (never commit secrets)
+.env
+.env.*
+!.env.local.example
+.dev.vars
+.dev.vars.*
+
+# Cloudflare local state
 .wrangler/
 
+# Keys / certificates
+*.key
+*.pem
+*.p12
+*.pfx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to Ninth Inning Email are documented here.
 
 ## [Unreleased]
 
+### Security
+- One-time secrets-exposure audit: gitleaks across all 62 commits and manual greps for `SUPABASE_SERVICE_ROLE`, `EMAIL_API_KEY`, `xkeysib-`, `CRON_SECRET`, and Stripe key prefixes confirmed no secrets have ever been committed; `wrangler.jsonc` `vars` only contain non-sensitive values (`SITE_URL`, `FROM_EMAIL`, `TIP_URL`); `supabase-admin.js` is only imported from server-side API routes; client components reference only `NEXT_PUBLIC_*` env vars; RLS is enabled on every `mlb_*` table (closes #56)
+
+### Added
+- `secret-scan` job in `.github/workflows/test.yml` running gitleaks on every PR and push to `main`, with `fetch-depth: 0` so the full history is scanned (closes #56)
+- "Configuration: vars vs. secrets" section in `CLAUDE.md` with the canonical secret list and per-secret rotation runbook targeting a 30-minute end-to-end rotation (closes #56)
+
 ### Changed
+- Tightened `.gitignore` to block `.env`, `.env.*`, `.dev.vars*`, `*.key`, `*.pem`, `*.p12`, `*.pfx`, while keeping `.env.local.example` tracked (closes #56)
 - Brevo `sender` now includes a friendly display name ("Ninth Inning Email") in `app/api/cron/route.js` and `app/api/test-email/route.js`, so inboxes show the brand instead of the raw `highlights@ninthinning.email` address (closes #19)
 - Extracted the Brevo transactional call into `lib/brevo.js` (`sendEmail` + `SENDER_NAME`); cron and test-email routes now share one implementation, and the helper accepts an injectable `fetchImpl` so it can be unit-tested without hitting Brevo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,62 @@ npm run deploy     # Deploy to Cloudflare
 - **Cloudflare Worker**: `mlb` (custom domain declared in `wrangler.jsonc` under `routes`)
 - **Email sender**: `Ninth Inning Email <highlights@ninthinning.email>` (Brevo, domain authenticated; display name set in `app/api/cron/route.js` and `app/api/test-email/route.js`)
 - **Supabase auth redirect**: `https://ninthinning.email/auth/callback`
-- `SITE_URL` and `FROM_EMAIL` are set as vars in `wrangler.jsonc`; secrets (Supabase keys, `EMAIL_API_KEY`, `CRON_SECRET`) are stored as Cloudflare Worker secrets via Wrangler
+
+## Configuration: vars vs. secrets
+
+Anything in `wrangler.jsonc` under `vars` is **public** — it ships baked into the worker and can be read by anyone who can run `wrangler deploy --dry-run`. Treat that file as if it were committed to a public repo (it is). Only put non-sensitive config there. Everything else lives as a Cloudflare Worker secret, set with `wrangler secret put`.
+
+### `vars` (public, in `wrangler.jsonc`)
+
+| Name | Purpose |
+|------|---------|
+| `SITE_URL` | Canonical site URL used for unsubscribe links and `metadataBase` |
+| `FROM_EMAIL` | Sender address on transactional email (`highlights@ninthinning.email`) |
+| `TIP_URL` | Stripe Payment Link for the tip jar (already a public URL) |
+
+### Secrets (Cloudflare Worker secrets, set via `wrangler secret put <NAME>`)
+
+| Name | Used by | Where it lives upstream |
+|------|---------|-------------------------|
+| `NEXT_PUBLIC_SUPABASE_URL` | server + browser Supabase clients | Supabase project settings → API |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | server + browser Supabase clients | Supabase project settings → API |
+| `SUPABASE_SERVICE_ROLE_KEY` | `lib/supabase-admin.js` (cron + unsubscribe only) | Supabase project settings → API → service_role |
+| `EMAIL_API_KEY` | `lib/brevo.js` | Brevo dashboard → SMTP & API → API keys |
+| `CRON_SECRET` | `/api/cron`, `/api/test-email` (Bearer auth) | Generated locally, e.g. `openssl rand -hex 32` |
+| `EMAILS_PAUSED` *(optional)* | Cron kill switch — set to `"true"` to halt sends | Set as a Worker var when needed (see `INCIDENT.md`) |
+
+> The `NEXT_PUBLIC_*` Supabase values are technically not secret (the anon key is shipped to the browser), but they're still stored as Worker secrets so production config lives in one place rather than being split between `vars` and `secret`. RLS is what protects the Supabase data — see `supabase-schema.sql`.
+
+To verify production matches this list:
+
+```bash
+npx wrangler secret list   # should match the secrets table above
+```
+
+If a secret is missing or extra, fix it before merging — missing-secret regressions have caused outages before (cf. issue #65).
+
+## Secret rotation runbook
+
+Target: any individual secret can be rotated end-to-end in **≤ 30 minutes** with zero email loss. Run through this list dry once per quarter so the steps stay current.
+
+General flow for every secret:
+
+1. **Mint** a new value in the upstream dashboard (links below). Do not revoke the old one yet.
+2. **Set** the new value as a Worker secret: `npx wrangler secret put <NAME>` and paste when prompted.
+3. **Deploy**: `npm run deploy`. Cloudflare hot-swaps secrets on the next request — no downtime.
+4. **Verify** the worker is using the new value (curl an endpoint, watch logs in the Cloudflare dashboard, or wait one cron tick).
+5. **Revoke** the old value upstream.
+6. **Record** the rotation in `INCIDENT.md` under "Incident log" with the date and reason.
+
+Per-secret specifics:
+
+- **`SUPABASE_SERVICE_ROLE_KEY`** — Supabase dashboard → Project Settings → API → "Reset service_role key". This invalidates the old key immediately, so do step 2 + 3 before clicking reset, then re-issue if needed. Outage window: any cron tick mid-rotation may fail; fine to wait until between hourly ticks.
+- **`NEXT_PUBLIC_SUPABASE_ANON_KEY`** — Same dashboard, "Reset anon key". Browsers holding old sessions will need to re-auth.
+- **`EMAIL_API_KEY`** — Brevo → SMTP & API → API keys → "Create a new API key", then delete the old key after step 4.
+- **`CRON_SECRET`** — `openssl rand -hex 32` locally → `wrangler secret put CRON_SECRET` → deploy. The cron only calls itself, so there is no third party to update.
+- **`TIP_URL`** *(not a secret, but rotated similarly)* — Edit `wrangler.jsonc` and redeploy.
+
+If you suspect a leak rather than a routine rotation, also: review `wrangler tail` for unauthorized requests over the last 24h, set `EMAILS_PAUSED=true` per `INCIDENT.md` if the leaked secret could send mail, and open an incident issue.
 
 ## Key Patterns
 


### PR DESCRIPTION
Closes #56.

## Summary

- Verified no secrets are committed (gitleaks across all 62 commits + manual greps for `SUPABASE_SERVICE_ROLE`, `EMAIL_API_KEY`, `xkeysib-`, `CRON_SECRET`, `sk_live_`/`sk_test_`, JWT tokens — all clean).
- Tightened `.gitignore` to block `.env`, `.env.*`, `.dev.vars*`, `*.key`, `*.pem`, `*.p12`, `*.pfx` while keeping `.env.local.example` tracked.
- Added a `secret-scan` job to `.github/workflows/test.yml` using `gitleaks/gitleaks-action@v2` with `fetch-depth: 0`, so any future leak fails the build.
- Documented the canonical vars-vs-secrets split and a 30-minute rotation runbook in `CLAUDE.md` so missing-secret regressions (cf. #65) are easier to catch in review and a leaked secret can be rotated end-to-end without guesswork.

## Audit findings (all green)

| Check | Result |
|---|---|
| `gitleaks detect --log-opts=--all` (62 commits) | 0 leaks |
| Manual history greps for known secret prefixes | Only legitimate variable-name references in code/docs |
| `wrangler.jsonc` `vars` | Only `SITE_URL`, `FROM_EMAIL`, `TIP_URL` — all non-sensitive |
| `supabase-admin.js` import sites | Only `app/api/cron/route.js`, `app/api/unsubscribe/route.js`, and the route's test mock — server-only |
| Client components (`use client`) referencing `process.env` | None |
| RLS on `mlb_*` tables | Enabled on all three with per-`auth.uid()` policies |

## Test plan

- [x] `npm test` passes (41/41)
- [x] `gitleaks detect --source . --log-opts=--all` reports no leaks
- [x] `git check-ignore` confirms `.env`, `.env.local`, `.dev.vars`, `*.key`, `*.pem` are ignored and `.env.local.example` is still tracked
- [ ] After merge: dry-run the rotation runbook against the real Supabase/Brevo dashboards to satisfy the issue's "dry-run end-to-end at least once" acceptance criterion
- [ ] After merge: confirm the `secret-scan` job runs green on `main`

## Out of scope (flagged for follow-up)

- **Pre-commit hook**: issue mentions both pre-commit and CI; I only added CI to avoid adding a hook framework as a contributor dependency. Easy to add later if wanted.
- **Production bundle grep**: skipped a full `npm run build` since static analysis already proves containment (only server-side files reference `SUPABASE_SERVICE_ROLE_KEY` / `EMAIL_API_KEY` / `CRON_SECRET`, and Next.js only inlines `NEXT_PUBLIC_*` into client bundles).
- **`mlb_users` view in `supabase-schema.sql`**: exposes `select id, email from auth.users`. RLS doesn't apply to views by default (they run with owner privileges). The cron uses the service role so it's fine in practice, but worth confirming the `anon`/`authenticated` roles can't `select * from mlb_users`. Not strictly in scope for #56.

https://claude.ai/code/session_017Shc81tow6nTe5DhVAZ8uL

---
_Generated by [Claude Code](https://claude.ai/code/session_017Shc81tow6nTe5DhVAZ8uL)_