### PR TITLE
Lock down public.mlb_users view to service_role only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Ninth Inning Email are documented here.
 ## [Unreleased]
 
 ### Security
+- Fixed email-enumeration leak via the `public.mlb_users` view: Postgres views run with the owner's privileges by default, so RLS on `auth.users` did not apply when `anon`/`authenticated` read the view, and any visitor with the (browser-shipped) anon key could list every signed-up user's id and email. Patched in production by `revoke all on public.mlb_users from anon, authenticated, public;`, and now baked into `supabase-schema.sql` so any new project bootstrapped from it isn't vulnerable. Service-role access (which the cron worker uses) is unaffected. Surfaced during the #56 audit
 - One-time secrets-exposure audit: gitleaks across all 62 commits and manual greps for `SUPABASE_SERVICE_ROLE`, `EMAIL_API_KEY`, `xkeysib-`, `CRON_SECRET`, and Stripe key prefixes confirmed no secrets have ever been committed; `wrangler.jsonc` `vars` only contain non-sensitive values (`SITE_URL`, `FROM_EMAIL`, `TIP_URL`); `supabase-admin.js` is only imported from server-side API routes; client components reference only `NEXT_PUBLIC_*` env vars; RLS is enabled on every `mlb_*` table (closes #56)
 
 ### Added

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -65,3 +65,11 @@ create policy "Users can view their own MLB notifications"
 -- (The cron worker uses the service role key which bypasses RLS)
 create view public.mlb_users as
   select id, email from auth.users;
+
+-- Lock the view down to service_role only. Postgres views run with the
+-- owner's privileges by default, so RLS on auth.users does NOT apply when
+-- anon/authenticated read this view. Without this revoke, any visitor with
+-- the anon key (which ships in the browser bundle) can list every signed-up
+-- user's email. The cron worker uses service_role, which bypasses grants,
+-- so it keeps working.
+revoke all on public.mlb_users from anon, authenticated, public;


### PR DESCRIPTION
## Summary

Locks down the `public.mlb_users` view to `service_role` only. The view (`select id, email from auth.users`) was created without an explicit grant, leaving Supabase's default grants in place — `SELECT` for `anon` and `authenticated`. Postgres views run with the **owner's** privileges, so RLS on `auth.users` did *not* apply, and any visitor with the (browser-shipped) anon key could list every signed-up user's email by calling `supabase.from('mlb_users').select('*')`.

Surfaced during the #56 audit but tracked separately because it's a distinct finding (data exposure, not credential exposure).

## What was done

1. **Confirmed the leak in production**: `information_schema.role_table_grants` showed `anon` had `SELECT` on `mlb_users`; a REST call from a browser DevTools console with the anon key returned `200` with real user rows.
2. **Patched in production** by running in the Supabase SQL editor:
   ```sql
   revoke all on public.mlb_users from anon, authenticated, public;
   ```
3. **Verified the fix**: the same REST call now returns `401`. Re-triggered `/api/cron` afterwards and confirmed the user fan-out still works (cron uses `service_role`, which bypasses grants).
4. **This PR** brings `supabase-schema.sql` in sync with production so any new Supabase project bootstrapped from it isn't vulnerable, with an inline comment explaining *why* the revoke is necessary.

## Test plan

- [x] `npm test` passes (41/41)
- [x] gitleaks clean (65 commits)
- [x] Production verified: anon-key REST call to `/rest/v1/mlb_users` returns `401`
- [x] Production verified: `/api/cron` still fans out emails (service_role unaffected)
- [ ] After merge: confirm CI is green on `main`

## Notes on disclosure

The leak exposed `id` and `email` for every signed-up user to anyone who knew the anon key (it ships in the browser bundle of the deployed site, so effectively public). User count was small at the time of the patch. Whether to notify existing users is a judgment call — flagging here so it isn't lost.

https://claude.ai/code/session_017Shc81tow6nTe5DhVAZ8uL

---
_Generated by [Claude Code](https://claude.ai/code/session_017Shc81tow6nTe5DhVAZ8uL)_