### PR TITLE
Cut 2026-04-30 release and document Supabase view-grants lesson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,19 @@ All notable changes to Ninth Inning Email are documented here.
 
 ## [Unreleased]
 
+## [2026-04-30]
+
 ### Security
-- Fixed email-enumeration leak via the `public.mlb_users` view: Postgres views run with the owner's privileges by default, so RLS on `auth.users` did not apply when `anon`/`authenticated` read the view, and any visitor with the (browser-shipped) anon key could list every signed-up user's id and email. Patched in production by `revoke all on public.mlb_users from anon, authenticated, public;`, and now baked into `supabase-schema.sql` so any new project bootstrapped from it isn't vulnerable. Service-role access (which the cron worker uses) is unaffected. Surfaced during the #56 audit
-- One-time secrets-exposure audit: gitleaks across all 62 commits and manual greps for `SUPABASE_SERVICE_ROLE`, `EMAIL_API_KEY`, `xkeysib-`, `CRON_SECRET`, and Stripe key prefixes confirmed no secrets have ever been committed; `wrangler.jsonc` `vars` only contain non-sensitive values (`SITE_URL`, `FROM_EMAIL`, `TIP_URL`); `supabase-admin.js` is only imported from server-side API routes; client components reference only `NEXT_PUBLIC_*` env vars; RLS is enabled on every `mlb_*` table (closes #56)
+- Fixed email-enumeration leak via the `public.mlb_users` view: Postgres views run with the owner's privileges by default, so RLS on `auth.users` did not apply when `anon`/`authenticated` read the view, and any visitor with the (browser-shipped) anon key could list every signed-up user's id and email. Patched in production by `revoke all on public.mlb_users from anon, authenticated, public;`, and now baked into `supabase-schema.sql` so any new project bootstrapped from it isn't vulnerable. Service-role access (which the cron worker uses) is unaffected. Surfaced during the #56 audit (PR #80)
+- One-time secrets-exposure audit: gitleaks across all 62 commits and manual greps for `SUPABASE_SERVICE_ROLE`, `EMAIL_API_KEY`, `xkeysib-`, `CRON_SECRET`, and Stripe key prefixes confirmed no secrets have ever been committed; `wrangler.jsonc` `vars` only contain non-sensitive values (`SITE_URL`, `FROM_EMAIL`, `TIP_URL`); `supabase-admin.js` is only imported from server-side API routes; client components reference only `NEXT_PUBLIC_*` env vars; RLS is enabled on every `mlb_*` table (PR #79, closes #56)
 
 ### Added
-- `secret-scan` job in `.github/workflows/test.yml` running gitleaks on every PR and push to `main`, with `fetch-depth: 0` so the full history is scanned (closes #56)
-- "Configuration: vars vs. secrets" section in `CLAUDE.md` with the canonical secret list and per-secret rotation runbook targeting a 30-minute end-to-end rotation (closes #56)
+- `secret-scan` job in `.github/workflows/test.yml` running gitleaks on every PR and push to `main`, with `fetch-depth: 0` so the full history is scanned (PR #79, closes #56)
+- "Configuration: vars vs. secrets" section in `CLAUDE.md` with the canonical secret list and per-secret rotation runbook targeting a 30-minute end-to-end rotation; rotation dry-run completed against `CRON_SECRET` and recorded in `INCIDENT.md` (PR #79, closes #56)
+- "Supabase schema conventions" note in `CLAUDE.md` capturing the `mlb_users`-view lesson: any view selecting from `auth.users` must explicitly revoke from `anon`/`authenticated`, since views inherit the owner's privileges and bypass RLS
 
 ### Changed
-- Tightened `.gitignore` to block `.env`, `.env.*`, `.dev.vars*`, `*.key`, `*.pem`, `*.p12`, `*.pfx`, while keeping `.env.local.example` tracked (closes #56)
+- Tightened `.gitignore` to block `.env`, `.env.*`, `.dev.vars*`, `*.key`, `*.pem`, `*.p12`, `*.pfx`, while keeping `.env.local.example` tracked (PR #79, closes #56)
 - Brevo `sender` now includes a friendly display name ("Ninth Inning Email") in `app/api/cron/route.js` and `app/api/test-email/route.js`, so inboxes show the brand instead of the raw `highlights@ninthinning.email` address (closes #19)
 - Extracted the Brevo transactional call into `lib/brevo.js` (`sendEmail` + `SENDER_NAME`); cron and test-email routes now share one implementation, and the helper accepts an injectable `fetchImpl` so it can be unit-tested without hitting Brevo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,3 +103,12 @@ If you suspect a leak rather than a routine rotation, also: review `wrangler tai
 - Server-side Supabase client uses `supabase-server.js`; admin operations use `supabase-admin.js` (service role key)
 - Auth flow uses Supabase magic links with callback at `app/auth/callback/route.js`
 - Middleware in `middleware.js` handles session refresh
+
+## Supabase schema conventions
+
+- Every `mlb_*` table has RLS enabled with per-`auth.uid()` policies; the cron worker uses `service_role` (which bypasses RLS) so adding RLS doesn't break the fan-out.
+- **Views need explicit grants.** Postgres views run with the owner's privileges, so RLS on the underlying table does **not** apply to the caller. Supabase's defaults grant `SELECT` to `anon` and `authenticated` on any new table or view in `public`. For any view that exposes data from `auth.users` (or any sensitive source), you must explicitly:
+  ```sql
+  revoke all on public.<view_name> from anon, authenticated, public;
+  ```
+  See `public.mlb_users` in `supabase-schema.sql` for the canonical example. Skipping this revoke caused an email-enumeration leak that was patched in PR #80.


### PR DESCRIPTION
## Summary

Documentation-only follow-up to PR #79 and PR #80, now that the audit work is in `main`:

- **CHANGELOG.md**: cut the `[Unreleased]` entries into a dated `[2026-04-30]` section, matching the project's per-release convention (e.g., `[2026-04-28]`). Adds PR references (#79, #80) so each entry is traceable.
- **CLAUDE.md**: add a "Supabase schema conventions" section that captures the lesson behind PR #80 — any view selecting from `auth.users` must explicitly revoke from `anon`/`authenticated`, since Postgres views run with the owner's privileges and bypass RLS. The `mlb_users` leak was caused by skipping this revoke and relying on Supabase defaults.

No code changes.

## Test plan

- [x] `npm test` passes (41/41)
- [x] gitleaks clean (66 commits)
- [x] CHANGELOG renders correctly (Unreleased empty, 2026-04-30 contains all five sections in the existing order)

https://claude.ai/code/session_017Shc81tow6nTe5DhVAZ8uL

---
_Generated by [Claude Code](https://claude.ai/code/session_017Shc81tow6nTe5DhVAZ8uL)_