### PR TITLE
Cron health: log runs to mlb_cron_runs + admin dashboard

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,6 +10,9 @@ FROM_EMAIL=highlights@ninthinning.email
 # Cron secret (prevents unauthorized access to /api/cron)
 CRON_SECRET=generate-a-random-string-here
 
+# Admin email — single email address allowed to view /admin
+ADMIN_EMAIL=you@example.com
+
 # Site URL (for unsubscribe links in emails)
 NEXT_PUBLIC_SITE_URL=https://ninthinning.email
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Anything in `wrangler.jsonc` under `vars` is **public** — it ships baked into 
 | `SUPABASE_SERVICE_ROLE_KEY` | `lib/supabase-admin.js` (cron + unsubscribe only) | Supabase project settings → API → service_role |
 | `EMAIL_API_KEY` | `lib/brevo.js` | Brevo dashboard → SMTP & API → API keys |
 | `CRON_SECRET` | `/api/cron`, `/api/test-email` (Bearer auth) | Generated locally, e.g. `openssl rand -hex 32` |
+| `ADMIN_EMAIL` | `/admin` page gating (single-user `notFound()` check) | Your Supabase auth email |
 | `EMAILS_PAUSED` *(optional)* | Cron kill switch — set to `"true"` to halt sends | Set as a Worker var when needed (see `INCIDENT.md`) |
 
 > The `NEXT_PUBLIC_*` Supabase values are technically not secret (the anon key is shipped to the browser), but they're still stored as Worker secrets so production config lives in one place rather than being split between `vars` and `secret`. RLS is what protects the Supabase data — see `supabase-schema.sql`.

--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -1,0 +1,169 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase-server";
+import { createAdminClient } from "@/lib/supabase-admin";
+
+export const dynamic = "force-dynamic";
+
+const STATUS_COLORS = {
+  success: "text-green-400",
+  partial: "text-yellow-400",
+  failure: "text-red-400",
+  running: "text-blue-400",
+  paused: "text-gray-400",
+  no_subscribers: "text-gray-500",
+  no_new_highlights: "text-gray-500",
+};
+
+function formatRelative(iso) {
+  if (!iso) return "—";
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const min = Math.round(diffMs / 60000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.round(hr / 24);
+  return `${d}d ago`;
+}
+
+function formatDuration(start, end) {
+  if (!start || !end) return "—";
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export default async function AdminPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+  if (!process.env.ADMIN_EMAIL || user.email !== process.env.ADMIN_EMAIL) {
+    notFound();
+  }
+
+  const admin = createAdminClient();
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [usersRes, emailsRes, runsRes] = await Promise.all([
+    admin.from("mlb_users").select("*", { count: "exact", head: true }),
+    admin
+      .from("mlb_sent_notifications")
+      .select("*", { count: "exact", head: true })
+      .gte("sent_at", sevenDaysAgo),
+    admin
+      .from("mlb_cron_runs")
+      .select("*")
+      .order("started_at", { ascending: false })
+      .limit(10),
+  ]);
+
+  const totalUsers = usersRes.count ?? 0;
+  const emailsLast7d = emailsRes.count ?? 0;
+  const runs = runsRes.data || [];
+  const lastRun = runs[0];
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-12">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold">Admin</h1>
+        <p className="mt-1 text-sm text-gray-400">
+          Health snapshot for {process.env.SITE_URL || "ninthinning.email"}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Stat label="Total users" value={totalUsers} />
+        <Stat label="Emails sent (7d)" value={emailsLast7d} />
+        <Stat
+          label="Last cron run"
+          value={lastRun ? formatRelative(lastRun.started_at) : "never"}
+          sub={
+            lastRun ? (
+              <span className={STATUS_COLORS[lastRun.status] || "text-gray-400"}>
+                {lastRun.status}
+              </span>
+            ) : null
+          }
+        />
+      </div>
+
+      <h2 className="mt-12 mb-3 text-sm font-medium text-gray-300">
+        Recent cron runs
+      </h2>
+      {runs.length === 0 ? (
+        <p className="text-sm text-gray-500">No runs logged yet.</p>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-800">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-900 text-left text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-4 py-2 font-medium">Started</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium text-right">Games</th>
+                <th className="px-4 py-2 font-medium text-right">Emails</th>
+                <th className="px-4 py-2 font-medium text-right">Errors</th>
+                <th className="px-4 py-2 font-medium text-right">Duration</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800">
+              {runs.map((run) => (
+                <tr key={run.id} className="text-gray-300">
+                  <td className="px-4 py-2 text-gray-400">
+                    {formatRelative(run.started_at)}
+                  </td>
+                  <td className={`px-4 py-2 font-medium ${STATUS_COLORS[run.status] || ""}`}>
+                    {run.status}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {run.games_processed}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {run.emails_sent}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {run.errors_count > 0 ? (
+                      <span className="text-red-400">{run.errors_count}</span>
+                    ) : (
+                      "0"
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-right text-gray-500 tabular-nums">
+                    {formatDuration(run.started_at, run.finished_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {lastRun?.errors?.length > 0 && (
+        <div className="mt-6">
+          <h3 className="mb-2 text-sm font-medium text-gray-300">
+            Errors in last run
+          </h3>
+          <ul className="space-y-1 rounded-lg border border-red-900/50 bg-red-950/20 p-4 text-xs text-red-300">
+            {lastRun.errors.map((err, i) => (
+              <li key={i} className="font-mono">
+                {err}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}
+
+function Stat({ label, value, sub }) {
+  return (
+    <div className="rounded-lg border border-gray-800 bg-gray-900 px-5 py-4">
+      <div className="text-xs uppercase tracking-wide text-gray-500">{label}</div>
+      <div className="mt-1 text-2xl font-semibold text-gray-100">{value}</div>
+      {sub && <div className="mt-1 text-xs">{sub}</div>}
+    </div>
+  );
+}

--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -14,6 +14,37 @@ import { sendEmail } from "@/lib/brevo";
 
 export const maxDuration = 60;
 
+async function startRun(supabase) {
+  const { data, error } = await supabase
+    .from("mlb_cron_runs")
+    .insert({ status: "running" })
+    .select("id")
+    .single();
+  if (error) {
+    console.error("Failed to insert mlb_cron_runs row:", error.message);
+    return null;
+  }
+  return data.id;
+}
+
+async function finalizeRun(supabase, runId, status, { gamesProcessed = 0, emailsSent = 0, errors = [] } = {}) {
+  if (!runId) return;
+  const { error } = await supabase
+    .from("mlb_cron_runs")
+    .update({
+      finished_at: new Date().toISOString(),
+      status,
+      games_processed: gamesProcessed,
+      emails_sent: emailsSent,
+      errors_count: errors.length,
+      errors: errors.length > 0 ? errors : null,
+    })
+    .eq("id", runId);
+  if (error) {
+    console.error("Failed to finalize mlb_cron_runs row:", error.message);
+  }
+}
+
 export async function GET(request) {
   // Verify cron secret to prevent unauthorized access
   const authHeader = request.headers.get("authorization");
@@ -21,167 +52,193 @@ export async function GET(request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const supabase = createAdminClient();
+
   // Kill switch: set EMAILS_PAUSED=true in Cloudflare dashboard to halt all sends instantly
   if (process.env.EMAILS_PAUSED === "true") {
+    const pausedRunId = await startRun(supabase);
+    await finalizeRun(supabase, pausedRunId, "paused");
     return NextResponse.json({ message: "Emails paused via kill switch" });
   }
 
-  const supabase = createAdminClient();
-  const dates = getDatesToCheck();
+  const runId = await startRun(supabase);
+  const errors = [];
 
-  // 1. Get all team IDs that at least one user follows
-  const { data: subscribedTeams } = await supabase
-    .from("mlb_user_teams")
-    .select("team_id")
-    .limit(1000);
+  try {
+    const dates = getDatesToCheck();
 
-  const teamIds = [...new Set((subscribedTeams || []).map((r) => r.team_id))];
+    // 1. Get all team IDs that at least one user follows
+    const { data: subscribedTeams } = await supabase
+      .from("mlb_user_teams")
+      .select("team_id")
+      .limit(1000);
 
-  if (teamIds.length === 0) {
-    return NextResponse.json({ message: "No subscribed teams" });
-  }
+    const teamIds = [...new Set((subscribedTeams || []).map((r) => r.team_id))];
 
-  console.log(`Checking ${teamIds.length} teams across dates: ${dates.join(", ")}`);
+    if (teamIds.length === 0) {
+      await finalizeRun(supabase, runId, "no_subscribers", { errors });
+      return NextResponse.json({ message: "No subscribed teams" });
+    }
 
-  // 2. For each team, fetch schedule and find final games
-  const newGames = [];
+    console.log(`Checking ${teamIds.length} teams across dates: ${dates.join(", ")}`);
 
-  for (const teamId of teamIds) {
-    for (const dateStr of dates) {
-      try {
-        const schedule = await fetchSchedule(teamId, dateStr);
-        const finals = extractFinalGames(schedule);
+    // 2. For each team, fetch schedule and find final games
+    const newGames = [];
 
-        for (const game of finals) {
-          // Check if we already have this game cached with a highlight URL
-          const { data: cached } = await supabase
-            .from("mlb_game_cache")
-            .select("highlight_url")
-            .eq("game_pk", game.gamePk)
-            .single();
+    for (const teamId of teamIds) {
+      for (const dateStr of dates) {
+        try {
+          const schedule = await fetchSchedule(teamId, dateStr);
+          const finals = extractFinalGames(schedule);
 
-          if (cached?.highlight_url) {
-            // Already have the highlight — just need to check for unsent notifications
-            newGames.push({
-              gamePk: game.gamePk,
-              teamId,
-              gameDate: dateStr,
-              highlightUrl: cached.highlight_url,
+          for (const game of finals) {
+            // Check if we already have this game cached with a highlight URL
+            const { data: cached } = await supabase
+              .from("mlb_game_cache")
+              .select("highlight_url")
+              .eq("game_pk", game.gamePk)
+              .single();
+
+            if (cached?.highlight_url) {
+              // Already have the highlight — just need to check for unsent notifications
+              newGames.push({
+                gamePk: game.gamePk,
+                teamId,
+                gameDate: dateStr,
+                highlightUrl: cached.highlight_url,
+              });
+              continue;
+            }
+
+            // Try to extract highlight URL
+            const content = await fetchGameContent(game.gamePk);
+            const url = extractHighlightUrl(content);
+
+            // Upsert into game_cache
+            await supabase.from("mlb_game_cache").upsert({
+              game_pk: game.gamePk,
+              team_id: teamId,
+              game_date: dateStr,
+              status: "final",
+              highlight_url: url,
+              checked_at: new Date().toISOString(),
             });
-            continue;
+
+            if (url) {
+              newGames.push({
+                gamePk: game.gamePk,
+                teamId,
+                gameDate: dateStr,
+                highlightUrl: url,
+              });
+            } else {
+              const contentKeys = Object.keys(content || {}).join(", ");
+              const hasHighlights = !!content?.highlights?.highlights?.items?.length;
+              const hasEpg = !!content?.media?.epg?.length;
+              console.log(
+                `No highlight for game ${game.gamePk} (team ${teamId}, date ${dateStr}). ` +
+                `Content keys: [${contentKeys}], hasLegacyHighlights: ${hasHighlights}, hasEpg: ${hasEpg}`
+              );
+            }
           }
+        } catch (err) {
+          const errMsg = `Error checking team ${teamId} on ${dateStr}: ${err.message}`;
+          console.error(errMsg);
+          errors.push(errMsg);
+        }
+      }
+    }
 
-          // Try to extract highlight URL
-          const content = await fetchGameContent(game.gamePk);
-          const url = extractHighlightUrl(content);
+    if (newGames.length === 0) {
+      await finalizeRun(supabase, runId, errors.length > 0 ? "partial" : "no_new_highlights", { errors });
+      return NextResponse.json({
+        message: "No new highlights available",
+        errors: errors.length > 0 ? errors : undefined,
+      });
+    }
 
-          // Upsert into game_cache
-          await supabase.from("mlb_game_cache").upsert({
+    // 3. For each game with highlights, find users to notify
+    let emailsSent = 0;
+    const skipped = [];
+
+    for (const game of newGames) {
+      const { data: subscribers } = await supabase
+        .from("mlb_user_teams")
+        .select("user_id")
+        .eq("team_id", game.teamId);
+
+      if (!subscribers?.length) {
+        skipped.push({ gamePk: game.gamePk, reason: "no_subscribers" });
+        continue;
+      }
+
+      for (const row of subscribers) {
+        const userId = row.user_id;
+
+        const { data: userData } = await supabase
+          .from("mlb_users")
+          .select("email")
+          .eq("id", userId)
+          .single();
+
+        const email = userData?.email;
+        if (!email) {
+          skipped.push({ gamePk: game.gamePk, userId, reason: "no_email" });
+          continue;
+        }
+
+        // Check if already notified
+        const { data: existing } = await supabase
+          .from("mlb_sent_notifications")
+          .select("id")
+          .eq("user_id", userId)
+          .eq("game_pk", game.gamePk)
+          .maybeSingle();
+
+        if (existing) {
+          skipped.push({ gamePk: game.gamePk, reason: "already_notified" });
+          continue;
+        }
+
+        // Send email
+        const team = TEAMS_BY_ID[game.teamId];
+        const teamName = team?.name || `Team ${game.teamId}`;
+        const subject = `${teamName} Highlights — ${formatDisplayDate(game.gameDate)}`;
+        const html = buildEmailHtml(team, game.highlightUrl, userId, game.gameDate);
+
+        try {
+          await sendEmail(email, subject, html);
+
+          await supabase.from("mlb_sent_notifications").insert({
+            user_id: userId,
             game_pk: game.gamePk,
-            team_id: teamId,
-            game_date: dateStr,
-            status: "final",
-            highlight_url: url,
-            checked_at: new Date().toISOString(),
           });
 
-          if (url) {
-            newGames.push({
-              gamePk: game.gamePk,
-              teamId,
-              gameDate: dateStr,
-              highlightUrl: url,
-            });
-          } else {
-            const contentKeys = Object.keys(content || {}).join(", ");
-            const hasHighlights = !!content?.highlights?.highlights?.items?.length;
-            const hasEpg = !!content?.media?.epg?.length;
-            console.log(
-              `No highlight for game ${game.gamePk} (team ${teamId}, date ${dateStr}). ` +
-              `Content keys: [${contentKeys}], hasLegacyHighlights: ${hasHighlights}, hasEpg: ${hasEpg}`
-            );
-          }
+          emailsSent++;
+        } catch (err) {
+          const errMsg = `Failed to email ${email} for game ${game.gamePk}: ${err.message}`;
+          console.error(errMsg);
+          errors.push(errMsg);
         }
-      } catch (err) {
-        console.error(`Error checking team ${teamId} on ${dateStr}:`, err.message);
       }
     }
+
+    await finalizeRun(supabase, runId, errors.length > 0 ? "partial" : "success", {
+      gamesProcessed: newGames.length,
+      emailsSent,
+      errors,
+    });
+
+    return NextResponse.json({
+      message: `Processed ${newGames.length} games, sent ${emailsSent} emails`,
+      errors: errors.length > 0 ? errors : undefined,
+      skipped: skipped.length > 0 ? skipped : undefined,
+    });
+  } catch (err) {
+    const errMsg = `Cron run failed: ${err.message}`;
+    console.error(errMsg, err);
+    errors.push(errMsg);
+    await finalizeRun(supabase, runId, "failure", { errors });
+    return NextResponse.json({ error: errMsg }, { status: 500 });
   }
-
-  if (newGames.length === 0) {
-    return NextResponse.json({ message: "No new highlights available" });
-  }
-
-  // 3. For each game with highlights, find users to notify
-  let emailsSent = 0;
-  const errors = [];
-  const skipped = [];
-
-  for (const game of newGames) {
-    const { data: subscribers } = await supabase
-      .from("mlb_user_teams")
-      .select("user_id")
-      .eq("team_id", game.teamId);
-
-    if (!subscribers?.length) {
-      skipped.push({ gamePk: game.gamePk, reason: "no_subscribers" });
-      continue;
-    }
-
-    for (const row of subscribers) {
-      const userId = row.user_id;
-
-      const { data: userData } = await supabase
-        .from("mlb_users")
-        .select("email")
-        .eq("id", userId)
-        .single();
-
-      const email = userData?.email;
-      if (!email) {
-        skipped.push({ gamePk: game.gamePk, userId, reason: "no_email" });
-        continue;
-      }
-
-      // Check if already notified
-      const { data: existing } = await supabase
-        .from("mlb_sent_notifications")
-        .select("id")
-        .eq("user_id", userId)
-        .eq("game_pk", game.gamePk)
-        .maybeSingle();
-
-      if (existing) {
-        skipped.push({ gamePk: game.gamePk, reason: "already_notified" });
-        continue;
-      }
-
-      // Send email
-      const team = TEAMS_BY_ID[game.teamId];
-      const teamName = team?.name || `Team ${game.teamId}`;
-      const subject = `${teamName} Highlights \u2014 ${formatDisplayDate(game.gameDate)}`;
-      const html = buildEmailHtml(team, game.highlightUrl, userId, game.gameDate);
-
-      try {
-        await sendEmail(email, subject, html);
-
-        await supabase.from("mlb_sent_notifications").insert({
-          user_id: userId,
-          game_pk: game.gamePk,
-        });
-
-        emailsSent++;
-      } catch (err) {
-        const errMsg = `Failed to email ${email} for game ${game.gamePk}: ${err.message}`;
-        console.error(errMsg);
-        errors.push(errMsg);
-      }
-    }
-  }
-
-  return NextResponse.json({
-    message: `Processed ${newGames.length} games, sent ${emailsSent} emails`,
-    errors: errors.length > 0 ? errors : undefined,
-    skipped: skipped.length > 0 ? skipped : undefined,
-  });
 }

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -73,3 +73,22 @@ create view public.mlb_users as
 -- user's email. The cron worker uses service_role, which bypasses grants,
 -- so it keeps working.
 revoke all on public.mlb_users from anon, authenticated, public;
+
+-- Cron run health log (one row per /api/cron invocation that gets past auth)
+create table public.mlb_cron_runs (
+  id uuid default gen_random_uuid() primary key,
+  started_at timestamptz default now() not null,
+  finished_at timestamptz,
+  status text not null default 'running',
+  games_processed integer not null default 0,
+  emails_sent integer not null default 0,
+  errors_count integer not null default 0,
+  errors jsonb
+);
+
+create index idx_mlb_cron_runs_started_at on public.mlb_cron_runs(started_at desc);
+
+-- Service-role-only: the cron writes via service_role (bypasses RLS) and the
+-- admin page reads via service_role too. RLS is enabled with no policies, so
+-- anon/authenticated get nothing.
+alter table public.mlb_cron_runs enable row level security;


### PR DESCRIPTION
Closes #86.

## Summary

- New `mlb_cron_runs` Supabase table — one row per authorized `/api/cron` invocation, capturing `started_at`, `finished_at`, `status`, `games_processed`, `emails_sent`, `errors_count`, and a jsonb `errors` array.
- `/api/cron` now inserts a `status='running'` row at the start, wraps the body in a top-level try/catch, and finalizes the row on every exit path (`success`, `partial`, `failure`, `paused`, `no_subscribers`, `no_new_highlights`). Inner-loop errors that previously only hit `console.error` are now persisted.
- New `/admin` server-rendered page, gated to `ADMIN_EMAIL` via `notFound()` so non-owners get a 404 (no information leak). Shows total users, emails sent in the last 7 days, last cron status with relative timestamp, a 10-run history table, and an errors panel for the latest run.
- `CLAUDE.md` secrets table and `.env.local.example` updated with `ADMIN_EMAIL`.

## Pre-merge checklist (production)

- [x] Run the new `create table public.mlb_cron_runs (...)` block in the Supabase SQL editor (already done by @nmartinovic)
- [x] Set `ADMIN_EMAIL` Cloudflare Worker secret to `nmartinovic@gmail.com`
- [ ] Merge → Cloudflare Workers Builds will deploy automatically

## Test plan

- [x] `npm test` — 41/41 passing
- [x] `npm run build` — clean, `/admin` registered as a dynamic route
- [ ] Post-deploy: visit `/admin` while logged in as the admin email → see stats + run table
- [ ] Post-deploy: visit `/admin` while logged out → redirects to `/login`
- [ ] Post-deploy: after the next cron tick, confirm a `mlb_cron_runs` row exists with `status='success'` (or `no_new_highlights` if there were no games)

## Design notes

- **Insert-at-start, update-at-end.** A row stuck in `running` for >1 hour is a useful "crashed" signal we'd otherwise lose to log retention.
- **`notFound()` over 403.** Non-admins can't tell `/admin` exists, which avoids advertising the surface.
- **Service-role-only RLS.** `mlb_cron_runs` has RLS enabled with no policies — both cron writes and admin reads go through the service role client, matching the existing `mlb_users` view pattern.

https://claude.ai/code/session_01FTLcZFoJ6Mt249p9t1Wcov

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTLcZFoJ6Mt249p9t1Wcov)_