### PR TITLE
Document cron-health work in CHANGELOG and CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Ninth Inning Email are documented here.
 
 ## [Unreleased]
 
+## [2026-05-01]
+
+### Added
+- `mlb_cron_runs` Supabase table — one row per authorized `/api/cron` invocation, capturing `started_at`, `finished_at`, `status` (`success` / `partial` / `failure` / `paused` / `no_subscribers` / `no_new_highlights` / `running`), `games_processed`, `emails_sent`, `errors_count`, and a jsonb `errors` array. Service-role-only via RLS-enabled-no-policies, matching the `mlb_users` view pattern (PR #87, closes #86)
+- Owner-only `/admin` dashboard at `app/admin/page.js` — gated by `ADMIN_EMAIL` Worker secret via `notFound()` so non-owners can't tell the route exists. Shows total users, emails sent in the last 7 days, last cron status with relative timestamp, a 10-run history table, and an errors panel for the latest run (PR #87, closes #86)
+- `ADMIN_EMAIL` Cloudflare Worker secret added to the `CLAUDE.md` secrets table and `.env.local.example`
+
+### Changed
+- `/api/cron` now wraps its body in a top-level try/catch and finalizes the `mlb_cron_runs` row on every exit path. Inner-loop errors that previously only hit `console.error` are now persisted to the `errors` jsonb column
+
+### Project management
+- Split #68 (umbrella "engagement + cron-health instrumentation") into three focused issues: #84 (product analytics), #85 (email engagement), #86 (cron health). Closed #68 as superseded
+
 ## [2026-04-30]
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,10 @@ npm run deploy     # Deploy to Cloudflare
 ## Project Structure
 
 - `app/` — Next.js App Router pages and API routes
-  - `api/cron/` — Cron worker that checks for completed games and sends emails
+  - `api/cron/` — Cron worker that checks for completed games and sends emails; logs each run to `mlb_cron_runs`
   - `api/unsubscribe/` — Unsubscribe API
   - `dashboard/` — Team selection UI
+  - `admin/` — Owner-only health dashboard (gated by `ADMIN_EMAIL` via `notFound()`); shows total users, emails sent in the last 7 days, and recent cron runs
   - `login/` — Magic link auth
 - `lib/` — Shared utilities
   - `mlb.js` — MLB Stats API client


### PR DESCRIPTION
Follow-up to #87.

## Summary

- New `2026-05-01` section in `CHANGELOG.md` covering the `mlb_cron_runs` table, `/admin` dashboard, `ADMIN_EMAIL` secret, and the cron try/catch instrumentation
- Notes the issue split: #68 → #84 (product analytics) / #85 (email engagement) / #86 (cron health)
- Updates the Project Structure section of `CLAUDE.md` to mention `app/admin/` and that `/api/cron` now logs runs

## Test plan

- [x] Doc-only change; no tests or build needed

https://claude.ai/code/session_01FTLcZFoJ6Mt249p9t1Wcov

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTLcZFoJ6Mt249p9t1Wcov)_