### PR TITLE
Harden rate limiting on the magic-link sign-in flow (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Ninth Inning Email are documented here.
 
 ## [Unreleased]
 
+### Security
+- Hardened rate limiting on the magic-link sign-in flow (closes #25). The login form previously called `supabase.auth.signInWithOtp` directly from the browser, so requests bypassed our Cloudflare worker entirely and the only rate limit was Supabase's defaults (30 req/5min per IP for sign-ins, 2 emails/hr project-wide on built-in SMTP). The form now POSTs to a new `/api/login` route which applies two `unsafe.bindings` rate limiters before calling Supabase server-side: `LOGIN_IP_LIMITER` (5 requests/60s per `cf-connecting-ip`) and `LOGIN_EMAIL_LIMITER` (3 requests/60s per normalized email). Either rejection returns 429. Audit findings and the new layer are documented in the "Rate limits on the magic-link flow" section of `CLAUDE.md` so future sessions don't re-investigate
+
+### Added
+- `app/api/login/route.test.js` covering input validation, both 429 paths, email normalization, Supabase error pass-through, and the no-binding fallback used in local dev
+- `wrangler.test.js` assertion locking in the `LOGIN_IP_LIMITER` and `LOGIN_EMAIL_LIMITER` bindings so a future config edit can't silently disable the rate limit
+
 ## [2026-05-01]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,25 @@ If you suspect a leak rather than a routine rotation, also: review `wrangler tai
 - Auth flow uses Supabase magic links with callback at `app/auth/callback/route.js`
 - Middleware in `middleware.js` handles session refresh
 
+## Rate limits on the magic-link flow
+
+Audited in issue #25. The login page (`app/login/page.js`) calls `supabase.auth.signInWithOtp` directly from the browser, so requests go straight to `<supabase>/auth/v1/otp` and **never traverse the Cloudflare worker or `middleware.js`**. A WAF rule on `/login` or `/api/*` would catch nothing.
+
+Effective limits today (Supabase dashboard → Auth → Rate Limits):
+
+| Bucket | Limit | Scope |
+|--------|-------|-------|
+| Sign-ups and sign-ins (`signInWithOtp`) | 30 requests / 5 min | per IP |
+| Sending emails (built-in SMTP) | 2 emails / hour | **project-wide** |
+
+Implications:
+
+- Email-flood abuse against third parties is inherently capped at 2/hour project-wide.
+- That same cap means an attacker can DoS legitimate sign-ins for ~everyone with 2 requests/hour. Mitigation is custom SMTP, not rate limiting — tracked separately from #25.
+- No Cloudflare WAF rate-limit rules are configured on this account; the magic-link path is governed entirely by the Supabase limits above.
+
+If we add more rate limiting in the future it must live behind a server-side proxy (e.g. `app/api/login/route.js`) that the login form POSTs to, since the browser-direct call to Supabase cannot be intercepted at our edge.
+
 ## Supabase schema conventions
 
 - Every `mlb_*` table has RLS enabled with per-`auth.uid()` policies; the cron worker uses `service_role` (which bypasses RLS) so adding RLS doesn't break the fan-out.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,22 +108,31 @@ If you suspect a leak rather than a routine rotation, also: review `wrangler tai
 
 ## Rate limits on the magic-link flow
 
-Audited in issue #25. The login page (`app/login/page.js`) calls `supabase.auth.signInWithOtp` directly from the browser, so requests go straight to `<supabase>/auth/v1/otp` and **never traverse the Cloudflare worker or `middleware.js`**. A WAF rule on `/login` or `/api/*` would catch nothing.
+Audited and hardened in issue #25. The login form POSTs to `/api/login` (`app/api/login/route.js`), which validates the email, applies our own rate limits, and then calls `supabase.auth.signInWithOtp` server-side. The form no longer talks to Supabase directly — that's deliberate, because a browser-direct call bypasses our worker entirely and cannot be rate-limited at the edge.
 
-Effective limits today (Supabase dashboard → Auth → Rate Limits):
+Two layers of limits apply:
+
+**1. Our worker (`/api/login`)** — Cloudflare Rate Limiting bindings declared in `wrangler.jsonc` under `unsafe.bindings`:
+
+| Binding | Limit | Key |
+|---------|-------|-----|
+| `LOGIN_IP_LIMITER` | 5 requests / 60s | `cf-connecting-ip` |
+| `LOGIN_EMAIL_LIMITER` | 3 requests / 60s | normalized email |
+
+Either bucket's rejection returns HTTP 429 before the request reaches Supabase. (Cloudflare's simple rate limiter only supports `period: 10` or `period: 60` seconds; per-hour buckets would need KV/D1.)
+
+**2. Supabase (Project Settings → Auth → Rate Limits)** — applies to whatever still reaches Supabase:
 
 | Bucket | Limit | Scope |
 |--------|-------|-------|
 | Sign-ups and sign-ins (`signInWithOtp`) | 30 requests / 5 min | per IP |
 | Sending emails (built-in SMTP) | 2 emails / hour | **project-wide** |
 
-Implications:
+Implications and known gaps:
 
-- Email-flood abuse against third parties is inherently capped at 2/hour project-wide.
-- That same cap means an attacker can DoS legitimate sign-ins for ~everyone with 2 requests/hour. Mitigation is custom SMTP, not rate limiting — tracked separately from #25.
-- No Cloudflare WAF rate-limit rules are configured on this account; the magic-link path is governed entirely by the Supabase limits above.
-
-If we add more rate limiting in the future it must live behind a server-side proxy (e.g. `app/api/login/route.js`) that the login form POSTs to, since the browser-direct call to Supabase cannot be intercepted at our edge.
+- The 2 emails/hour Supabase cap is **project-wide** — abuse-flood against third parties is inherently bounded, but so are legitimate sign-ins. Mitigation for that is custom SMTP, tracked separately from #25.
+- No Cloudflare WAF rate-limit rules are configured on this account; the per-IP/per-email enforcement lives entirely in the worker bindings above. A WAF rule on `POST /api/login` would be a reasonable belt-and-suspenders addition.
+- The bindings are no-ops in tests and `next dev` (the worker runtime isn't present); enforcement only kicks in after `npm run deploy`. The route handles missing bindings gracefully and falls through to Supabase, so local dev still works.
 
 ## Supabase schema conventions
 

--- a/app/api/login/route.js
+++ b/app/api/login/route.js
@@ -1,0 +1,79 @@
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+function getClientIp(request) {
+  return (
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    "unknown"
+  );
+}
+
+async function getEnv() {
+  try {
+    const mod = await import("@opennextjs/cloudflare");
+    return mod.getCloudflareContext().env ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export async function POST(request) {
+  let payload;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const email =
+    typeof payload?.email === "string"
+      ? payload.email.trim().toLowerCase()
+      : "";
+
+  if (!email || email.length > 254 || !EMAIL_RE.test(email)) {
+    return NextResponse.json({ error: "Invalid email" }, { status: 400 });
+  }
+
+  const env = await getEnv();
+  const ip = getClientIp(request);
+
+  if (env.LOGIN_IP_LIMITER) {
+    const { success } = await env.LOGIN_IP_LIMITER.limit({ key: `ip:${ip}` });
+    if (!success) {
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
+  }
+
+  if (env.LOGIN_EMAIL_LIMITER) {
+    const { success } = await env.LOGIN_EMAIL_LIMITER.limit({
+      key: `email:${email}`,
+    });
+    if (!success) {
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  );
+
+  const origin = new URL(request.url).origin;
+
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: { emailRedirectTo: `${origin}/auth/callback` },
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message || "Could not send magic link" },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/login/route.test.js
+++ b/app/api/login/route.test.js
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const signInWithOtp = vi.fn();
+const createClient = vi.fn();
+const getCloudflareContext = vi.fn();
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: (...args) => createClient(...args),
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: () => getCloudflareContext(),
+}));
+
+function makeRequest(body, { headers = {} } = {}) {
+  const init = {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+  };
+  if (body !== undefined) {
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+  return new Request("https://ninthinning.email/api/login", init);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+  signInWithOtp.mockResolvedValue({ error: null });
+  createClient.mockReturnValue({ auth: { signInWithOtp } });
+  getCloudflareContext.mockReturnValue({ env: {} });
+});
+
+describe("POST /api/login", () => {
+  it("rejects malformed JSON with 400", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest("not-json"));
+
+    expect(res.status).toBe(400);
+    expect(signInWithOtp).not.toHaveBeenCalled();
+  });
+
+  it("rejects an obviously invalid email with 400", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({ email: "not-an-email" }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid email" });
+    expect(signInWithOtp).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing email with 400", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({}));
+
+    expect(res.status).toBe(400);
+    expect(signInWithOtp).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when the per-IP limiter rejects", async () => {
+    const ipLimiter = { limit: vi.fn().mockResolvedValue({ success: false }) };
+    const emailLimiter = { limit: vi.fn() };
+    getCloudflareContext.mockReturnValue({
+      env: { LOGIN_IP_LIMITER: ipLimiter, LOGIN_EMAIL_LIMITER: emailLimiter },
+    });
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      makeRequest({ email: "user@example.com" }, { headers: { "cf-connecting-ip": "1.2.3.4" } })
+    );
+
+    expect(res.status).toBe(429);
+    expect(ipLimiter.limit).toHaveBeenCalledWith({ key: "ip:1.2.3.4" });
+    expect(emailLimiter.limit).not.toHaveBeenCalled();
+    expect(signInWithOtp).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when the per-email limiter rejects", async () => {
+    const ipLimiter = { limit: vi.fn().mockResolvedValue({ success: true }) };
+    const emailLimiter = { limit: vi.fn().mockResolvedValue({ success: false }) };
+    getCloudflareContext.mockReturnValue({
+      env: { LOGIN_IP_LIMITER: ipLimiter, LOGIN_EMAIL_LIMITER: emailLimiter },
+    });
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({ email: "User@Example.com" }));
+
+    expect(res.status).toBe(429);
+    expect(emailLimiter.limit).toHaveBeenCalledWith({
+      key: "email:user@example.com",
+    });
+    expect(signInWithOtp).not.toHaveBeenCalled();
+  });
+
+  it("calls Supabase signInWithOtp with normalized email and returns ok on success", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({ email: "  User@Example.com  " }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(signInWithOtp).toHaveBeenCalledWith({
+      email: "user@example.com",
+      options: {
+        emailRedirectTo: "https://ninthinning.email/auth/callback",
+      },
+    });
+  });
+
+  it("propagates Supabase errors as 400", async () => {
+    signInWithOtp.mockResolvedValueOnce({ error: { message: "rate limited" } });
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({ email: "user@example.com" }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "rate limited" });
+  });
+
+  it("works when no rate limiter bindings are present", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({ email: "user@example.com" }));
+
+    expect(res.status).toBe(200);
+    expect(signInWithOtp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { createClient } from "@/lib/supabase-browser";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -14,20 +13,34 @@ export default function LoginPage() {
     setLoading(true);
     setError(null);
 
-    const supabase = createClient();
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback`,
-      },
-    });
+    let res;
+    try {
+      res = await fetch("/api/login", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+    } catch {
+      setLoading(false);
+      setError("Network error. Please try again.");
+      return;
+    }
 
     setLoading(false);
-    if (error) {
-      setError(error.message);
-    } else {
-      setSent(true);
+
+    if (res.status === 429) {
+      setError("Too many requests. Please wait a minute and try again.");
+      return;
     }
+
+    const data = await res.json().catch(() => ({}));
+
+    if (!res.ok) {
+      setError(data.error || "Could not send magic link.");
+      return;
+    }
+
+    setSent(true);
   }
 
   if (sent) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,6 +16,22 @@
     "FROM_EMAIL": "highlights@ninthinning.email",
     "TIP_URL": "https://buy.stripe.com/28E3cv4w0aDs2yVg16dZ600"
   },
+  "unsafe": {
+    "bindings": [
+      {
+        "name": "LOGIN_IP_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1001",
+        "simple": { "limit": 5, "period": 60 }
+      },
+      {
+        "name": "LOGIN_EMAIL_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1002",
+        "simple": { "limit": 3, "period": 60 }
+      }
+    ]
+  },
   "observability": {
     "logs": {
       "enabled": true,

--- a/wrangler.test.js
+++ b/wrangler.test.js
@@ -22,4 +22,18 @@ describe("wrangler.jsonc", () => {
     expect(config.vars?.SITE_URL).toBe("https://ninthinning.email");
     expect(config.vars?.FROM_EMAIL).toBe("highlights@ninthinning.email");
   });
+
+  it("declares per-IP and per-email rate limit bindings for /api/login (#25)", () => {
+    const bindings = config.unsafe?.bindings ?? [];
+    const byName = Object.fromEntries(bindings.map((b) => [b.name, b]));
+
+    expect(byName.LOGIN_IP_LIMITER).toMatchObject({
+      type: "ratelimit",
+      simple: { limit: 5, period: 60 },
+    });
+    expect(byName.LOGIN_EMAIL_LIMITER).toMatchObject({
+      type: "ratelimit",
+      simple: { limit: 3, period: 60 },
+    });
+  });
 });


### PR DESCRIPTION
Closes #25.

## Audit (step 1 of the issue)

The login form previously called `supabase.auth.signInWithOtp` directly from the browser, so requests went straight to `<supabase>/auth/v1/otp` and **never traversed the Cloudflare worker or `middleware.js`**. A WAF rule on `/login` or `/api/*` would have caught nothing.

Effective limits before this PR (Supabase dashboard → Auth → Rate Limits):

| Bucket | Limit | Scope |
|--------|-------|-------|
| Sign-ups and sign-ins (`signInWithOtp`) | 30 requests / 5 min | per IP |
| Sending emails (built-in SMTP) | 2 emails / hour | **project-wide** |

The 2 emails/hour cap is project-wide on Supabase's built-in SMTP (no custom SMTP configured). That bounds third-party flood abuse but also means an attacker can DoS legitimate sign-ins with 2 requests/hour. Mitigation for *that* is custom SMTP and is out of scope for #25.

No Cloudflare WAF rate-limit rules are configured on this account.

## Change (step 2 of the issue)

Routes the login form through a new `/api/login` endpoint so requests actually hit our worker, where two `unsafe.bindings` ratelimit bindings reject abusive traffic with 429 before reaching Supabase:

| Binding | Limit | Key |
|---------|-------|-----|
| `LOGIN_IP_LIMITER` | 5 requests / 60s | `cf-connecting-ip` |
| `LOGIN_EMAIL_LIMITER` | 3 requests / 60s | normalized email |

Cloudflare's simple rate limiter only supports `period: 10` or `period: 60` seconds; per-hour buckets would need KV/D1 and are not in scope here.

### Files

- `app/api/login/route.js` — new POST endpoint: validates email, applies per-IP then per-email limiters, calls `signInWithOtp` server-side. Falls through gracefully when bindings aren't present (local dev / tests).
- `app/login/page.js` — POSTs to `/api/login` instead of calling Supabase directly. Surfaces 429 with a friendly message.
- `wrangler.jsonc` — declares `LOGIN_IP_LIMITER` and `LOGIN_EMAIL_LIMITER` under `unsafe.bindings`.
- `app/api/login/route.test.js` — 7 tests covering validation, both 429 paths, email normalization, Supabase error pass-through, and the no-binding fallback.
- `wrangler.test.js` — locks in the new bindings so a future config edit can't silently disable the rate limit.
- `CLAUDE.md` — new "Rate limits on the magic-link flow" section documenting the layered limits + known gaps.
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Test plan

- [x] `npm test` — 50/50 passing (was 41 + 9 new)
- [x] `npm run build` — clean; `/api/login` registered as a dynamic route
- [ ] After merge + deploy: `for i in $(seq 1 8); do curl -s -o /dev/null -w "%{http_code}\n" -X POST https://ninthinning.email/api/login -H 'content-type: application/json' -d '{"email":"abuse-test+$i@example.com"}'; done` — first 5 should be 200, requests 6–8 should be 429
- [ ] Sign in normally with a real email and confirm the magic link still arrives

## Deploy note

The rate-limit bindings only activate after `wrangler deploy` runs (the bindings are created/updated as part of the deploy). If a Cloudflare Workers Builds GitHub integration is wired to this repo, merge will trigger that automatically; otherwise run `npm run deploy` after merge.

https://claude.ai/code/session_01JcaRnqfaAJzMfZUNV8aCdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcaRnqfaAJzMfZUNV8aCdN)_