### PR TITLE
Write skipped_no_wake heartbeat row from cron early-return (#104)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Two Cloudflare cron triggers wired in `wrangler.jsonc`, routed to different endp
 | Cron | Endpoint | Purpose |
 |------|----------|---------|
 | `0 13 * * *` (daily, 9am ET in EDT) | `/api/cron/schedule` | Pulls today's MLB slate via `fetchDailySchedule`, upserts one row per game into `mlb_cron_schedule` with `expected_finish_at = first_pitch + 3.5h`, prunes rows older than 36h |
-| `*/15 * * * *` (every 15 min) | `/api/cron` | Reads `mlb_cron_schedule`; if no row's `expected_finish_at` is inside the polling window it returns early (no MLB API hits, no Supabase writes). Otherwise runs the full check + send fan-out |
+| `*/15 * * * *` (every 15 min) | `/api/cron` | Reads `mlb_cron_schedule`; if no row's `expected_finish_at` is inside the polling window it returns early (no MLB API hits) but still writes a `skipped_no_wake` heartbeat row to `mlb_cron_runs` (#104). Otherwise runs the full check + send fan-out |
 
 The polling window is asymmetric: `expected_finish_at` between `now - 2.5h` and `now + 30m`. Starting 30 min before the predicted finish catches short games; continuing 2.5h after catches extra innings and rain delays. Constants live at the top of `app/api/cron/route.js` (`EARLY_BOUND_MS`, `LATE_BOUND_MS`).
 
@@ -155,7 +155,7 @@ Failure modes worth knowing:
 - **Game runs longer than 6h** (extra innings + rain) → the polling window expires and the every-15-min cron stops checking. The next day's scheduler doesn't re-add yesterday's games, but the existing `getDatesToCheck` helper in `lib/mlb.js` keeps the *full-run* path looking back 2 days, so the **next** valid wake (a different team's game today) will catch the late finisher when it runs the fan-out.
 - **DST**: `0 13 * * *` UTC is 9am EDT (most of the MLB regular season) and 8am EST (March/late-October). Both are fine — early-morning is the goal, not exactly 9am.
 
-`mlb_cron_runs` statuses to expect from this stack: `running`, `success`, `partial`, `failure`, `paused`, `no_subscribers`, `no_new_highlights` (main cron) and `schedule_running`, `schedule_built`, `schedule_partial`, `schedule_failure` (scheduler). The early-return path intentionally writes **no** row, per #76's "exits within 50ms without hitting Supabase write paths" acceptance criterion — so an empty cron-runs hour during offseason is the success signal, not a problem.
+`mlb_cron_runs` statuses to expect from this stack: `running`, `success`, `partial`, `failure`, `paused`, `no_subscribers`, `no_new_highlights`, `skipped_no_wake` (main cron) and `schedule_running`, `schedule_built`, `schedule_partial`, `schedule_failure` (scheduler). Per postmortem #103 / #104, every `*/15` tick now writes exactly one row — silence is treated as a failure mode, so an empty `mlb_cron_runs` hour means the cron itself isn't running and should page, not "no game in window."
 
 ## Supabase schema conventions
 

--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -71,7 +71,9 @@ export async function GET(request) {
 
   // Early-return when no game in mlb_cron_schedule has expected_finish_at
   // inside the polling window. This is the offseason / overnight fast path
-  // (#76) — no MLB API calls, no Supabase writes, single indexed read.
+  // (#76) — no MLB API calls beyond the single indexed schedule read. Per
+  // postmortem #103 every tick still writes a heartbeat row to mlb_cron_runs
+  // (status 'skipped_no_wake') so silence is no longer ambiguous.
   const now = Date.now();
   const windowStart = new Date(now - LATE_BOUND_MS).toISOString();
   const windowEnd = new Date(now + EARLY_BOUND_MS).toISOString();
@@ -87,6 +89,8 @@ export async function GET(request) {
     // rather than dropping emails. Log so #68 dashboards surface it.
     console.error("mlb_cron_schedule read failed, falling through:", scheduleError.message);
   } else if (!activeWakes || activeWakes.length === 0) {
+    const heartbeatRunId = await startRun(supabase);
+    await finalizeRun(supabase, heartbeatRunId, "skipped_no_wake");
     return NextResponse.json({ message: "No scheduled wake within window — skipped" });
   }
 

--- a/app/api/cron/route.test.js
+++ b/app/api/cron/route.test.js
@@ -92,7 +92,7 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
     expect(createAdminClient).not.toHaveBeenCalled();
   });
 
-  it("skips early — no MLB API, no run row — when no wake is in the window", async () => {
+  it("skips early — no MLB API — but writes a heartbeat row when no wake is in the window (#104)", async () => {
     const { client, inserted, updates } = makeSupabaseMock({ scheduleRows: [] });
     createAdminClient.mockReturnValue(client);
 
@@ -104,8 +104,17 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
       message: "No scheduled wake within window — skipped",
     });
     expect(fetchSchedule).not.toHaveBeenCalled();
-    expect(inserted).toHaveLength(0);
-    expect(updates).toHaveLength(0);
+    // One heartbeat row: insert (status: running) + update (status: skipped_no_wake).
+    expect(inserted).toEqual([{ status: "running" }]);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      status: "skipped_no_wake",
+      games_processed: 0,
+      emails_sent: 0,
+      errors_count: 0,
+      errors: null,
+    });
+    expect(updates[0].finished_at).toEqual(expect.any(String));
   });
 
   it("queries mlb_cron_schedule with an asymmetric window (now-2.5h, now+30m)", async () => {


### PR DESCRIPTION
## Summary

Closes #104. Per postmortem #103, the `*/15` `/api/cron` early-return branch wrote nothing to `mlb_cron_runs`, leaving "scheduler broken" indistinguishable from "no game in window." Every tick now writes exactly one heartbeat row so silence is a failure signal.

- `app/api/cron/route.js` — early-return now calls `startRun` + `finalizeRun(..., "skipped_no_wake")`. `started_at` and `finished_at` are both set; `games_processed` / `emails_sent` are 0; `errors` is null.
- `app/api/cron/route.test.js` — updated the early-return test to assert the heartbeat insert + update with `status: skipped_no_wake` and zeroed counters.
- `CLAUDE.md` — added `skipped_no_wake` to the documented status list, updated the cron-architecture table, and replaced the "empty cron-runs hour is the success signal" guidance with the inverse (silence is a failure mode, per postmortem #103).

No schema change — `status` is free-text. Adds ~96 rows/day; cost is negligible.

## Test plan

- [x] `npm test` — all 68 tests pass, including the updated `route.test.js` heartbeat assertion
- [ ] After deploy, confirm `mlb_cron_runs` shows `skipped_no_wake` rows during the offseason / overnight window
- [ ] Confirm a row with both `started_at` and `finished_at` populated and `errors` null
- [ ] Verify the existing `EMAILS_PAUSED` and full-run paths still write their respective rows (no regression)

https://claude.ai/code/session_01R6Fddj2EwYYwr4cLkDvgit

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6Fddj2EwYYwr4cLkDvgit)_