### PR TITLE
Add out-of-band SLO alarms via pg_cron + pg_net (#107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,78 @@ Failure modes worth knowing:
 
 `mlb_cron_runs` statuses to expect from this stack: `running`, `success`, `partial`, `failure`, `paused`, `no_subscribers`, `no_new_highlights`, `skipped_no_wake` (main cron) and `schedule_running`, `schedule_built`, `schedule_partial`, `schedule_failure` (scheduler). Per postmortem #103 / #104, every `*/15` tick now writes exactly one row — silence is treated as a failure mode, so an empty `mlb_cron_runs` hour means the cron itself isn't running and should page, not "no game in window."
 
+## Out-of-band SLO alarms (#107)
+
+The `/admin` banner is passive — it only helps if the operator looks. A pg_cron job inside Supabase runs every 5 minutes and emails `ADMIN_EMAIL` directly when either silent-failure SLO trips:
+
+| SLO | Condition | Catches |
+|-----|-----------|---------|
+| **B1** (`schedule_stale_26h`) | No `schedule_*` row in `mlb_cron_runs` for 26h | Daily 9am-ET scheduler is dead |
+| **B2** (`cron_silent_30m`) | No row in `mlb_cron_runs` for 30m, **April–October ET only** | Cloudflare cron triggers themselves are down |
+
+Emails fire on `not firing → firing` edge transitions only. Recovery is silent (no "all clear" email) so a flapping SLO doesn't spam. State per SLO lives in `public.mlb_alarm_state`.
+
+The pg_cron job calls `public.mlb_check_slo_alarms()`, which uses `pg_net.http_post` to hit the Brevo transactional API directly — no Cloudflare worker involved, so this stays up even if the worker is the thing that's broken. Brevo creds come from Supabase Vault, not from Worker secrets.
+
+### One-time setup
+
+The first time you apply `supabase-schema.sql` against a project, you must:
+
+1. **Enable extensions** in Supabase dashboard → Database → Extensions: turn on `pg_cron` and `pg_net`. The `create extension if not exists` calls in the schema will then succeed; on a project where the SQL-editor role can't `CREATE EXTENSION` directly, the dashboard toggle is the only path.
+2. **Set Vault secrets** — Supabase dashboard → Project Settings → Vault → New secret (or run via SQL editor):
+   ```sql
+   select vault.create_secret('<brevo transactional key>', 'brevo_api_key');
+   select vault.create_secret('highlights@ninthinning.email', 'from_email');
+   select vault.create_secret('<your admin email>', 'admin_email');
+   ```
+   Reuse the same Brevo key as `EMAIL_API_KEY` on the Worker. To rotate, run `select vault.update_secret(id, '<new value>')`.
+
+### Verifying it's still active
+
+```sql
+-- Job is registered and active
+select jobname, schedule, active, command from cron.job where jobname = 'mlb-slo-alarms';
+
+-- Recent runs (succeeded?)
+select * from cron.job_run_details
+ where jobid = (select jobid from cron.job where jobname = 'mlb-slo-alarms')
+ order by start_time desc limit 5;
+
+-- Current SLO state
+select * from public.mlb_alarm_state;
+
+-- Recent outbound HTTP calls from pg_net (failures live here, not in raise)
+select id, status_code, error_msg, created from net._http_response order by created desc limit 5;
+```
+
+### Silencing during planned maintenance
+
+To pause both alarms (e.g. before deliberately stopping the cron for an upgrade):
+
+```sql
+select cron.unschedule('mlb-slo-alarms');
+```
+
+To resume — re-run the `do $$ ... cron.schedule('mlb-slo-alarms', ...) ... $$` block from `supabase-schema.sql`. Reset stale state if needed:
+
+```sql
+update public.mlb_alarm_state set firing = false, last_changed_at = now();
+```
+
+For very short pauses (<5 min) the simpler approach is to just expect one alarm email and ignore it — re-arming is automatic on the next non-firing tick.
+
+### Manual test
+
+```sql
+-- Force-trip B1: pretend nothing has been written for 26h+ by clearing
+-- recent schedule rows in a scratch DB, then run the function manually.
+select public.mlb_check_slo_alarms();
+-- Inspect: should send one email and flip mlb_alarm_state.firing = true.
+-- Calling again should NOT send a second email (edge-only).
+```
+
+In production, the natural test is to `cron.unschedule('main')` for the every-15-min cron in Cloudflare for >30 min during the season and confirm B2 fires within 5 min.
+
 ## Supabase schema conventions
 
 - Every `mlb_*` table has RLS enabled with per-`auth.uid()` policies; the cron worker uses `service_role` (which bypasses RLS) so adding RLS doesn't break the fan-out.

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -110,3 +110,173 @@ create index idx_mlb_cron_schedule_expected_finish on public.mlb_cron_schedule(e
 
 -- Service-role-only: only the cron worker reads/writes this table.
 alter table public.mlb_cron_schedule enable row level security;
+
+-- Out-of-band SLO alarms (#107). A pg_cron job runs every 5 minutes and
+-- emails ADMIN_EMAIL when either of these silent-failure SLOs trip:
+--   B1: no row with status starting 'schedule_' in mlb_cron_runs for 26h.
+--   B2: no row at all in mlb_cron_runs for 30m, during MLB regular season
+--       (April–October in America/New_York).
+-- We only email on edge transitions (not firing -> firing) so a stuck
+-- alarm doesn't spam every 5 minutes. Recovery is silent.
+--
+-- Prereqs (enable once via Supabase dashboard → Database → Extensions):
+--   - pg_cron  (lets Postgres run scheduled SQL)
+--   - pg_net   (lets SQL make outbound HTTP requests)
+-- The CREATE EXTENSION calls below are idempotent and will succeed if the
+-- extensions are already enabled. On hosted Supabase, only project owners
+-- can enable these — if these statements fail with "permission denied",
+-- enable them in the dashboard first.
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- Vault secrets the alarm function reads (set via Supabase dashboard →
+-- Project Settings → Vault, or `select vault.create_secret(...)`):
+--   - brevo_api_key  the same Brevo transactional key as EMAIL_API_KEY
+--   - from_email     same value as the FROM_EMAIL worker var
+--   - admin_email    same value as the ADMIN_EMAIL worker secret
+-- Storing these in Vault keeps them off disk and out of pg_dump.
+
+-- Per-SLO state. last_notified_at is informational; firing is what gates
+-- the next email. Rows are seeded below.
+create table if not exists public.mlb_alarm_state (
+  slo_id text primary key,
+  firing boolean not null default false,
+  last_changed_at timestamptz not null default now(),
+  last_notified_at timestamptz
+);
+
+alter table public.mlb_alarm_state enable row level security;
+
+insert into public.mlb_alarm_state (slo_id, firing) values
+  ('schedule_stale_26h', false),
+  ('cron_silent_30m', false)
+on conflict (slo_id) do nothing;
+
+-- Email sender. Reads Brevo creds from Vault and posts asynchronously via
+-- pg_net. pg_net.http_post returns immediately; failures land in
+-- net._http_response and do not raise here.
+create or replace function public._mlb_send_alarm_email(p_subject text, p_body text)
+returns void
+language plpgsql
+security definer
+set search_path = public, vault, net
+as $$
+declare
+  v_brevo_key text;
+  v_from text;
+  v_admin text;
+begin
+  select decrypted_secret into v_brevo_key from vault.decrypted_secrets where name = 'brevo_api_key';
+  select decrypted_secret into v_from      from vault.decrypted_secrets where name = 'from_email';
+  select decrypted_secret into v_admin     from vault.decrypted_secrets where name = 'admin_email';
+
+  if v_brevo_key is null or v_from is null or v_admin is null then
+    raise warning 'mlb_alarm: missing vault secret (brevo_api_key/from_email/admin_email); skipping send';
+    return;
+  end if;
+
+  perform net.http_post(
+    url := 'https://api.brevo.com/v3/smtp/email',
+    headers := jsonb_build_object(
+      'api-key', v_brevo_key,
+      'Content-Type', 'application/json',
+      'Accept', 'application/json'
+    ),
+    body := jsonb_build_object(
+      'sender', jsonb_build_object('email', v_from, 'name', 'Ninth Inning Alarm'),
+      'to', jsonb_build_array(jsonb_build_object('email', v_admin)),
+      'subject', p_subject,
+      'htmlContent', '<pre>' || p_body || '</pre>'
+    )
+  );
+end;
+$$;
+
+-- Evaluate both SLOs and fire on edge transitions only.
+create or replace function public.mlb_check_slo_alarms()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_now timestamptz := now();
+  v_in_season boolean := extract(month from (v_now at time zone 'America/New_York')) between 4 and 10;
+  v_schedule_recent_count int;
+  v_cron_recent_count int;
+  v_schedule_firing boolean;
+  v_cron_firing boolean;
+  v_prev_schedule boolean;
+  v_prev_cron boolean;
+begin
+  select count(*) into v_schedule_recent_count
+  from public.mlb_cron_runs
+  where status like 'schedule_%'
+    and started_at > v_now - interval '26 hours';
+
+  select count(*) into v_cron_recent_count
+  from public.mlb_cron_runs
+  where started_at > v_now - interval '30 minutes';
+
+  v_schedule_firing := v_schedule_recent_count = 0;
+  v_cron_firing := v_in_season and v_cron_recent_count = 0;
+
+  select firing into v_prev_schedule from public.mlb_alarm_state where slo_id = 'schedule_stale_26h';
+  select firing into v_prev_cron     from public.mlb_alarm_state where slo_id = 'cron_silent_30m';
+
+  -- B1: schedule_* row missing for 26h
+  if v_schedule_firing and not coalesce(v_prev_schedule, false) then
+    perform public._mlb_send_alarm_email(
+      '[ninthinning] SLO B1 firing: scheduler silent for 26h',
+      format(
+        'No row with status starting "schedule_" has been written to mlb_cron_runs in the last 26 hours.%s' ||
+        'The daily 9am-ET scheduler (/api/cron/schedule) may be broken. Check /admin and the Cloudflare cron triggers.%s' ||
+        'Detected at: %s UTC',
+        E'\n\n', E'\n\n', v_now
+      )
+    );
+    update public.mlb_alarm_state
+       set firing = true, last_changed_at = v_now, last_notified_at = v_now
+     where slo_id = 'schedule_stale_26h';
+  elsif (not v_schedule_firing) and coalesce(v_prev_schedule, false) then
+    update public.mlb_alarm_state
+       set firing = false, last_changed_at = v_now
+     where slo_id = 'schedule_stale_26h';
+  end if;
+
+  -- B2: any row missing for 30m, in-season only
+  if v_cron_firing and not coalesce(v_prev_cron, false) then
+    perform public._mlb_send_alarm_email(
+      '[ninthinning] SLO B2 firing: cron silent for 30m',
+      format(
+        'No rows have been written to mlb_cron_runs in the last 30 minutes, and we are in MLB regular season (Apr–Oct ET).%s' ||
+        'The Cloudflare cron triggers may be down — every-15-min /api/cron should be writing a heartbeat row each tick.%s' ||
+        'Detected at: %s UTC',
+        E'\n\n', E'\n\n', v_now
+      )
+    );
+    update public.mlb_alarm_state
+       set firing = true, last_changed_at = v_now, last_notified_at = v_now
+     where slo_id = 'cron_silent_30m';
+  elsif (not v_cron_firing) and coalesce(v_prev_cron, false) then
+    update public.mlb_alarm_state
+       set firing = false, last_changed_at = v_now
+     where slo_id = 'cron_silent_30m';
+  end if;
+end;
+$$;
+
+-- Schedule: every 5 minutes. Idempotent — drops any prior schedule under
+-- the same name before re-creating, so re-running this file in the SQL
+-- editor is safe.
+do $$
+begin
+  if exists (select 1 from cron.job where jobname = 'mlb-slo-alarms') then
+    perform cron.unschedule('mlb-slo-alarms');
+  end if;
+  perform cron.schedule(
+    'mlb-slo-alarms',
+    '*/5 * * * *',
+    $job$select public.mlb_check_slo_alarms()$job$
+  );
+end $$;


### PR DESCRIPTION
Closes #107.

## Summary

Adds an active alarm path for the two silent-failure SLOs called out in postmortem #103. The `/admin` banner is passive — it only helps if the operator looks. This adds a pg_cron job inside Supabase that runs every 5 minutes and emails `ADMIN_EMAIL` directly when either SLO trips, so an outage finds *us* instead of the other way around. Running entirely inside Supabase keeps the watcher up even if the Cloudflare worker is the thing that's broken.

| SLO | Condition | Catches |
|-----|-----------|---------|
| **B1** (`schedule_stale_26h`) | No `schedule_*` row in `mlb_cron_runs` for 26h | Daily 9am-ET scheduler is dead |
| **B2** (`cron_silent_30m`) | No row in `mlb_cron_runs` for 30m, **April–October ET only** | Cloudflare cron triggers themselves are down |

Emails fire on `not firing → firing` edge transitions only — recovery is silent and a stuck alarm doesn't spam every 5 minutes. Per-SLO state lives in `public.mlb_alarm_state`.

## Implementation

All-SQL change in `supabase-schema.sql`:

- `create extension if not exists pg_cron, pg_net` (operator must enable them in the Supabase dashboard first; the schema includes a comment noting this)
- `mlb_alarm_state` table — one row per SLO tracking `firing` / `last_changed_at` / `last_notified_at`, RLS enabled, seeded with both SLOs in non-firing state
- `_mlb_send_alarm_email()` — reads Brevo creds from Supabase Vault (`brevo_api_key`, `from_email`, `admin_email`) and posts asynchronously via `pg_net.http_post`. Missing-secret case logs a warning and returns rather than raising
- `mlb_check_slo_alarms()` — evaluates B1 and B2 (B2 gated to `extract(month from now() at time zone 'America/New_York') between 4 and 10`), compares to prior state, fires email + flips state on edge transitions only
- Idempotent `cron.schedule('mlb-slo-alarms', '*/5 * * * *', ...)` block — drops any prior schedule under the same name first, so re-running the SQL editor block is safe

CLAUDE.md gains a runbook covering: which SLOs are watched, one-time setup (extensions + Vault secrets), verification queries, how to silence during planned maintenance (`cron.unschedule('mlb-slo-alarms')`), and a manual test recipe.

No JS code touched. All 68 vitest tests still pass.

## Test plan

- [x] Vitest suite passes (`npm test`)
- [x] Operator enabled `pg_cron` + `pg_net` in the Supabase dashboard
- [x] Operator created Vault secrets `brevo_api_key`, `from_email`, `admin_email`
- [x] Operator ran the new SQL block in the Supabase SQL editor
- [x] `select * from cron.job where jobname = 'mlb-slo-alarms'` shows the job, `active = true`
- [x] `select * from public.mlb_alarm_state` shows both SLOs at `firing = false`
- [x] End-to-end self-test of `_mlb_send_alarm_email()` produced an email and a `201` row in `net._http_response`
- [ ] Future natural test: `cron.unschedule('main')` for the every-15-min Cloudflare cron during the season for >30 min, confirm B2 fires within 5 min

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmDtoZYnyf4HV4hYGwokX2)_