### PR TITLE
Fail open in main cron when mlb_cron_schedule is empty in season (#109)

### DIFF
--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -22,6 +22,21 @@ export const maxDuration = 60;
 const EARLY_BOUND_MS = 30 * 60 * 1000;
 const LATE_BOUND_MS = 2.5 * 60 * 60 * 1000;
 
+// MLB regular season runs roughly April–October ET. Used to decide whether an
+// empty mlb_cron_schedule should fail open (#109): in season we assume the
+// daily scheduler is broken and run the full check; out of season an empty
+// table is the expected steady state and we keep the cheap early-return.
+function isInMlbSeason() {
+  const month = parseInt(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: "America/New_York",
+      month: "numeric",
+    }).format(new Date()),
+    10
+  );
+  return month >= 4 && month <= 10;
+}
+
 async function startRun(supabase) {
   const { data, error } = await supabase
     .from("mlb_cron_runs")
@@ -89,9 +104,30 @@ export async function GET(request) {
     // rather than dropping emails. Log so #68 dashboards surface it.
     console.error("mlb_cron_schedule read failed, falling through:", scheduleError.message);
   } else if (!activeWakes || activeWakes.length === 0) {
-    const heartbeatRunId = await startRun(supabase);
-    await finalizeRun(supabase, heartbeatRunId, "skipped_no_wake");
-    return NextResponse.json({ message: "No scheduled wake within window — skipped" });
+    // No wake in window. Distinguish "table populated, just nothing due now"
+    // (the common offseason / overnight case — keep the cheap early-return)
+    // from "table is entirely empty" (the daily scheduler may be down — per
+    // #109, fail open during MLB season so a scheduler outage doesn't drop
+    // up to 24h of emails).
+    const { data: anyRows, error: anyRowsError } = await supabase
+      .from("mlb_cron_schedule")
+      .select("game_pk")
+      .limit(1);
+
+    if (anyRowsError) {
+      console.error(
+        "mlb_cron_schedule emptiness check failed, falling through:",
+        anyRowsError.message
+      );
+    } else if ((!anyRows || anyRows.length === 0) && isInMlbSeason()) {
+      console.warn(
+        "mlb_cron_schedule is empty during MLB season — scheduler may be down, falling through to full check (#109)"
+      );
+    } else {
+      const heartbeatRunId = await startRun(supabase);
+      await finalizeRun(supabase, heartbeatRunId, "skipped_no_wake");
+      return NextResponse.json({ message: "No scheduled wake within window — skipped" });
+    }
   }
 
   const runId = await startRun(supabase);

--- a/app/api/cron/route.test.js
+++ b/app/api/cron/route.test.js
@@ -22,7 +22,19 @@ vi.mock("@/lib/brevo", () => ({
 
 // Build a supabase mock whose mlb_cron_schedule query returns a configurable
 // result. Other tables get inert no-op handlers.
-function makeSupabaseMock({ scheduleRows = [], scheduleError = null } = {}) {
+//
+// `scheduleRows` / `scheduleError` drive the windowed query (gte/lte/limit).
+// `anyRows` / `anyError` drive the unwindowed emptiness check (#109): a bare
+// `.select().limit(1)` used to distinguish "table empty (scheduler may be
+// down)" from "table populated but no row in window (offseason/overnight)".
+// Default `anyRows` to non-empty so existing tests exercise the common
+// "populated but no wake" branch.
+function makeSupabaseMock({
+  scheduleRows = [],
+  scheduleError = null,
+  anyRows = [{ game_pk: 1 }],
+  anyError = null,
+} = {}) {
   const inserted = [];
   const updates = [];
 
@@ -34,6 +46,7 @@ function makeSupabaseMock({ scheduleRows = [], scheduleError = null } = {}) {
             limit: async () => ({ data: scheduleRows, error: scheduleError }),
           }),
         }),
+        limit: async () => ({ data: anyRows, error: anyError }),
       }),
     }),
     mlb_cron_runs: () => ({
@@ -92,7 +105,9 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
     expect(createAdminClient).not.toHaveBeenCalled();
   });
 
-  it("skips early — no MLB API — but writes a heartbeat row when no wake is in the window (#104)", async () => {
+  it("skips early — no MLB API — but writes a heartbeat row when the table is populated and no wake is in the window (#104)", async () => {
+    // Table has rows (anyRows defaults non-empty) but none in the polling
+    // window — the common offseason / overnight case.
     const { client, inserted, updates } = makeSupabaseMock({ scheduleRows: [] });
     createAdminClient.mockReturnValue(client);
 
@@ -134,6 +149,9 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
             },
           };
         },
+        // Unwindowed emptiness check (#109): table is non-empty so the
+        // route falls into the heartbeat branch, not the in-season fall-open.
+        limit: async () => ({ data: [{ game_pk: 1 }], error: null }),
       }),
     };
 
@@ -181,6 +199,55 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
     // the point is that we got past the early-return on a schedule read error.
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ message: "No subscribed teams" });
+  });
+
+  it("falls through to the full check when mlb_cron_schedule is empty during MLB season (#109)", async () => {
+    // Pin the system clock to May (in season, ET).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T20:00:00Z"));
+
+    const { client } = makeSupabaseMock({
+      scheduleRows: [],
+      anyRows: [], // table is entirely empty — scheduler may be down
+    });
+    createAdminClient.mockReturnValue(client);
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest());
+
+    // Mock has no subscribed teams, so the full run completes with
+    // "no_subscribers" — the point is that we got past the early-return
+    // instead of writing a skipped_no_wake heartbeat.
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ message: "No subscribed teams" });
+
+    vi.useRealTimers();
+  });
+
+  it("stays as a heartbeat when mlb_cron_schedule is empty during the offseason (#109)", async () => {
+    // Pin to January — out of season in ET.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T20:00:00Z"));
+
+    const { client, inserted, updates } = makeSupabaseMock({
+      scheduleRows: [],
+      anyRows: [], // table is empty, but offseason — expected steady state
+    });
+    createAdminClient.mockReturnValue(client);
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      message: "No scheduled wake within window — skipped",
+    });
+    expect(fetchSchedule).not.toHaveBeenCalled();
+    expect(inserted).toEqual([{ status: "running" }]);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({ status: "skipped_no_wake" });
+
+    vi.useRealTimers();
   });
 
   it("respects EMAILS_PAUSED and short-circuits before the schedule read", async () => {


### PR DESCRIPTION
Closes #109.

## Summary

- When the windowed `mlb_cron_schedule` query returns no rows, run a second unwindowed `.limit(1)` to check whether the table is entirely empty.
- If empty **and** ET month ∈ [4..10] (MLB regular season): fall through to the full check path so a daily-scheduler outage no longer drops up to 24h of emails. Logged as a warning.
- Otherwise (table populated but nothing in window, or empty during offseason): keep the existing cheap `skipped_no_wake` heartbeat.
- The schedule-read error path still falls open as before.

This decouples the main cron from the daily scheduler — the early-return becomes a pure efficiency optimization rather than a correctness gate. Trade-off acknowledged in the issue: ~96 extra full-run ticks/day during a scheduler outage, which is acceptable for this app's scale.

## Test plan

- [x] `npm test` — 70/70 passing (was 68/68; +2 new tests).
- [x] New: empty schedule + May → full check runs (asserts `no_subscribers` from the mock fan-out, proving we got past the early-return).
- [x] New: empty schedule + January → heartbeat stays (`skipped_no_wake`).
- [x] Updated: existing "no wake in window" test now exercises the populated-but-no-wake branch (the common offseason / overnight case).
- [x] Existing: schedule read error still falls through; `EMAILS_PAUSED` still short-circuits before the schedule read; bearer auth still enforced.

https://claude.ai/code/session_01Ltame3TVUUL8anJrKcncZd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ltame3TVUUL8anJrKcncZd)_