### PR TITLE
Align OG/Twitter card text with marketing spec (#124)

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -13,18 +13,18 @@ export const metadata = {
   keywords: ["MLB", "baseball", "highlights", "spoiler-free", "recap", "email"],
   alternates: { canonical: "/" },
   openGraph: {
-    title: "Ninth Inning Email — Spoiler-free MLB recaps",
+    title: "Ninth Inning Email — Spoiler-Free MLB Game Recaps",
     description:
-      "Pick your teams. We email the recap. No scores, no spoilers.",
+      "Get a spoiler-free highlight reel in your inbox after every game your team plays. No scores. No spoilers. Just the best plays.",
     url: "/",
     siteName: "Ninth Inning Email",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Ninth Inning Email — Spoiler-free MLB recaps",
+    title: "Ninth Inning Email — Spoiler-Free MLB Game Recaps",
     description:
-      "Pick your teams. We email the recap. No scores, no spoilers.",
+      "Get a spoiler-free highlight reel in your inbox after every game your team plays. No scores. No spoilers. Just the best plays.",
   },
 };
 

--- a/app/twitter-image.js
+++ b/app/twitter-image.js
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from "./opengraph-image";


### PR DESCRIPTION
## Summary

Closes #124.

- `app/layout.js` — update `openGraph.title`/`description` and `twitter.title`/`description` to match the exact strings called out in #124 ("Spoiler-Free MLB Game Recaps" + the longer description). The previous copy was the shorter pre-marketing version.
- `app/twitter-image.js` (new) — re-export the renderer from `app/opengraph-image.js` so Twitter gets an explicit `twitter:image` via Next.js's file-based convention, rather than relying on platform fallback.

The 1200×630 PNG is still generated by the existing `app/opengraph-image.js` (`next/og` `ImageResponse`) and served from the Cloudflare worker — no external image host, no Lighthouse regression risk. `og:url` resolves to the absolute `https://ninthinning.email/` via the existing `metadataBase` + `url: "/"`.

## Test plan

- [x] `npm run test` — 71/71 pass
- [ ] Post-deploy: paste `https://ninthinning.email` into [opengraph.xyz](https://www.opengraph.xyz/) and confirm title/description/image render
- [ ] Post-deploy: paste into Twitter, Reddit, iMessage, Discord and confirm the 1200×630 branded card renders

https://claude.ai/code/session_013brU2hToiemVDiepsm33Rm

---
_Generated by [Claude Code](https://claude.ai/code/session_013brU2hToiemVDiepsm33Rm)_