### PR TITLE
Send a one-time welcome email on first team selection (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,16 @@ Events currently captured:
 
 Autocapture and session recording are disabled — only the explicit events above. Pageviews and pageleaves are captured automatically by PostHog. To add a new event, import `track` from `@/lib/analytics` and call it from a `"use client"` component.
 
+## Welcome email (#26)
+
+A one-time welcome email fires the first time a user adds a team in `/dashboard`. The trigger lives client-side in `app/dashboard/team-grid.js` — after a successful insert into `mlb_user_teams`, it fires-and-forgets a POST to `/api/welcome`.
+
+`POST /api/welcome` (`app/api/welcome/route.js`) authenticates via the Supabase session (no `CRON_SECRET` required), confirms the user has at least one team, and delegates to `sendWelcomeEmailIfNeeded` in `lib/welcome-email.js`.
+
+Idempotency uses a sentinel row in `mlb_sent_notifications` with `game_pk = 0` (no schema change). The helper does claim-then-send: insert the sentinel first, then send. If the insert fails with Postgres `23505` (unique violation), a previous call already won and we skip. If `sendEmail` throws, the sentinel is rolled back so a retry can succeed. This makes "remove all teams, re-add" a no-op — the sentinel persists.
+
+The email template is `buildWelcomeEmailHtml` in `lib/email-template.js`. Same 520px card layout as the recap email but with a brand-green accent (no team color, since there's no team), three "how it works" bullets, and a CTA back to `/dashboard`.
+
 ## Supabase schema conventions
 
 - Every `mlb_*` table has RLS enabled with per-`auth.uid()` policies; the cron worker uses `service_role` (which bypasses RLS) so adding RLS doesn't break the fan-out.

--- a/app/api/welcome/route.js
+++ b/app/api/welcome/route.js
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase-server";
+import { createAdminClient } from "@/lib/supabase-admin";
+import { sendWelcomeEmailIfNeeded } from "@/lib/welcome-email";
+
+export async function POST() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+
+  const { data: teams, error: teamsError } = await admin
+    .from("mlb_user_teams")
+    .select("team_id")
+    .eq("user_id", user.id)
+    .limit(1);
+
+  if (teamsError) {
+    return NextResponse.json(
+      { error: `Failed to read teams: ${teamsError.message}` },
+      { status: 500 }
+    );
+  }
+
+  if (!teams || teams.length === 0) {
+    return NextResponse.json({ sent: false, reason: "no_teams" });
+  }
+
+  try {
+    const result = await sendWelcomeEmailIfNeeded({
+      supabase: admin,
+      userId: user.id,
+      email: user.email,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/app/dashboard/team-grid.js
+++ b/app/dashboard/team-grid.js
@@ -36,6 +36,10 @@ export default function TeamGrid({ teams, followedIds: initialFollowed }) {
         .from("mlb_user_teams")
         .insert({ user_id: user.id, team_id: teamId });
       track("team_selected", { team_id: teamId });
+      // Fire-and-forget: the API route is idempotent (sentinel row in
+      // mlb_sent_notifications), so calling on every add is safe and only
+      // the first one sends mail.
+      fetch("/api/welcome", { method: "POST" }).catch(() => {});
     }
 
     startTransition(() => router.refresh());

--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -1,5 +1,115 @@
 import { formatDisplayDate } from "@/lib/mlb";
 
+const BRAND_GREEN = "#2c5e4e";
+
+function getSiteUrl() {
+  return (
+    process.env.SITE_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    "https://yourdomain.com"
+  );
+}
+
+export function buildWelcomeEmailHtml(userId) {
+  const siteUrl = getSiteUrl();
+  const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
+  const dashboardUrl = `${siteUrl}/dashboard`;
+  const tipUrl = process.env.TIP_URL;
+  const accent = BRAND_GREEN;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Welcome to Ninth Inning Email</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;">
+<tr><td align="center" style="padding:24px 16px;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;background-color:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+
+  <!-- Brand accent bar -->
+  <tr><td style="height:6px;background-color:${accent};"></td></tr>
+
+  <!-- Title -->
+  <tr><td style="padding:28px 32px 0 32px;">
+    <h1 style="margin:0;font-size:22px;font-weight:700;color:#18181b;line-height:1.3;">You&#39;re in.</h1>
+    <p style="margin:8px 0 0 0;font-size:15px;color:#52525b;line-height:1.5;">Your spoiler-free recaps start as soon as your team&#39;s next game wraps.</p>
+  </td></tr>
+
+  <!-- How it works -->
+  <tr><td style="padding:24px 32px 0 32px;">
+    <p style="margin:0 0 10px 0;font-size:13px;font-weight:700;letter-spacing:0.5px;color:#71717a;text-transform:uppercase;">How it works</p>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td style="padding:6px 0;font-size:14px;color:#3f3f46;line-height:1.55;">
+          &bull; Recaps land within a few hours of the final out &mdash; usually first thing the next morning.
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;font-size:14px;color:#3f3f46;line-height:1.55;">
+          &bull; Subject lines and previews never reveal the score. Open when you&#39;re ready.
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;font-size:14px;color:#3f3f46;line-height:1.55;">
+          &bull; One tap takes you to the official MLB.com highlight reel.
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- CTA Button -->
+  <tr><td style="padding:24px 32px 0 32px;">
+    <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
+      <tr><td align="center">
+        <a href="${dashboardUrl}" style="display:inline-block;background-color:${accent};color:#ffffff;font-size:16px;font-weight:600;text-decoration:none;padding:14px 36px;border-radius:8px;letter-spacing:0.3px;">Manage your teams</a>
+      </td></tr>
+    </table>
+  </td></tr>
+
+  <!-- Footer divider -->
+  <tr><td style="padding:32px 32px 0 32px;">
+    <hr style="margin:0;border:none;border-top:1px solid #e4e4e7;">
+  </td></tr>
+
+  ${tipUrl ? `
+  <!-- Tip prompt -->
+  <tr><td align="center" style="padding:18px 32px 0 32px;">
+    <p style="margin:0;font-size:13px;color:#52525b;line-height:1.5;">
+      Enjoying Ninth Inning Email? <a href="${tipUrl}" style="color:${accent};text-decoration:underline;font-weight:600;">Tip the developer</a> to keep it running.
+    </p>
+  </td></tr>
+  ` : ""}
+
+  <!-- Footer -->
+  <tr><td style="padding:16px 32px 0 32px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td style="font-size:13px;color:#a1a1aa;">
+          <strong style="color:#52525b;">Ninth Inning Email</strong><br>
+          Spoiler-free MLB recaps
+        </td>
+        <td align="right" style="font-size:12px;vertical-align:top;">
+          <a href="${unsubscribeUrl}" style="color:#a1a1aa;text-decoration:underline;">Unsubscribe</a>
+        </td>
+      </tr>
+    </table>
+  </td></tr>
+
+  <!-- Disclaimer -->
+  <tr><td style="padding:12px 32px 28px 32px;">
+    <p style="margin:0;font-size:11px;color:#a1a1aa;line-height:1.5;">Ninth Inning Email is not affiliated with, endorsed by, or sponsored by MLB or any MLB club. Questions or takedown requests: <a href="mailto:abuse@ninthinning.email" style="color:#a1a1aa;">abuse@ninthinning.email</a></p>
+  </td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
 export function buildEmailHtml(team, highlightUrl, userId, gameDate) {
   const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || "https://yourdomain.com";
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildEmailHtml } from "./email-template";
+import { buildEmailHtml, buildWelcomeEmailHtml } from "./email-template";
 
 const TEAM = { id: 147, name: "New York Yankees", abbr: "NYY", color: "#003087" };
 const HIGHLIGHT_URL = "https://example.com/highlight.mp4";
@@ -78,5 +78,67 @@ describe("buildEmailHtml", () => {
     const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE);
     expect(html).toContain(`/unsubscribe?token=${USER_ID}`);
     expect(html).toContain(">Unsubscribe<");
+  });
+});
+
+describe("buildWelcomeEmailHtml", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.SITE_URL;
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+    delete process.env.TIP_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("includes the one-line welcome and the spoiler-free promise", () => {
+    const html = buildWelcomeEmailHtml(USER_ID);
+    expect(html).toContain("You&#39;re in.");
+    expect(html).toContain(
+      "Your spoiler-free recaps start as soon as your team&#39;s next game wraps."
+    );
+  });
+
+  it("explains post-game timing, no scores in subject/preview, and the highlight link", () => {
+    const html = buildWelcomeEmailHtml(USER_ID);
+    expect(html.toLowerCase()).toContain("final out");
+    expect(html.toLowerCase()).toContain("subject");
+    expect(html.toLowerCase()).toContain("score");
+    expect(html.toLowerCase()).toContain("highlight");
+  });
+
+  it("links the CTA back to /dashboard on SITE_URL", () => {
+    process.env.SITE_URL = "https://ninthinning.email";
+    const html = buildWelcomeEmailHtml(USER_ID);
+    expect(html).toContain('href="https://ninthinning.email/dashboard"');
+    expect(html).toContain("Manage your teams");
+  });
+
+  it("includes unsubscribe link with user token", () => {
+    process.env.SITE_URL = "https://ninthinning.email";
+    const html = buildWelcomeEmailHtml(USER_ID);
+    expect(html).toContain(
+      `https://ninthinning.email/unsubscribe?token=${USER_ID}`
+    );
+    expect(html).toContain(">Unsubscribe<");
+  });
+
+  it("includes the non-affiliation disclaimer and brand sender block", () => {
+    const html = buildWelcomeEmailHtml(USER_ID);
+    expect(html).toContain("Ninth Inning Email");
+    expect(html).toContain("not affiliated with");
+  });
+
+  it("includes the tip prompt only when TIP_URL is set", () => {
+    let html = buildWelcomeEmailHtml(USER_ID);
+    expect(html).not.toContain("Tip the developer");
+
+    process.env.TIP_URL = "https://buymeacoffee.com/example";
+    html = buildWelcomeEmailHtml(USER_ID);
+    expect(html).toContain("Tip the developer");
+    expect(html).toContain("https://buymeacoffee.com/example");
   });
 });

--- a/lib/welcome-email.js
+++ b/lib/welcome-email.js
@@ -1,0 +1,51 @@
+import { buildWelcomeEmailHtml } from "@/lib/email-template";
+import { sendEmail } from "@/lib/brevo";
+
+// Sentinel game_pk used to record that a user has received the one-time
+// welcome email. Re-using mlb_sent_notifications keeps the schema unchanged
+// (issue #26) and the existing unique (user_id, game_pk) constraint enforces
+// idempotency atomically.
+export const WELCOME_SENTINEL_GAME_PK = 0;
+
+const WELCOME_SUBJECT = "Welcome to Ninth Inning Email";
+
+// Idempotently send the welcome email. Claim-then-send order: insert the
+// sentinel row first so concurrent calls (e.g. rapid-fire team toggles) can't
+// both win the race. If the send fails, the sentinel is rolled back so the
+// next attempt can retry.
+//
+// Returns { sent: true } on first successful send,
+//         { sent: false, reason: "already_sent" } if previously sent,
+//         { sent: false, reason: "no_email" } if the user has no email.
+export async function sendWelcomeEmailIfNeeded({ supabase, userId, email, sendImpl = sendEmail }) {
+  if (!email) {
+    return { sent: false, reason: "no_email" };
+  }
+
+  const { error: insertError } = await supabase
+    .from("mlb_sent_notifications")
+    .insert({ user_id: userId, game_pk: WELCOME_SENTINEL_GAME_PK });
+
+  if (insertError) {
+    if (insertError.code === "23505") {
+      return { sent: false, reason: "already_sent" };
+    }
+    throw new Error(
+      `Failed to claim welcome sentinel: ${insertError.message}`
+    );
+  }
+
+  try {
+    const html = buildWelcomeEmailHtml(userId);
+    await sendImpl(email, WELCOME_SUBJECT, html);
+  } catch (err) {
+    await supabase
+      .from("mlb_sent_notifications")
+      .delete()
+      .eq("user_id", userId)
+      .eq("game_pk", WELCOME_SENTINEL_GAME_PK);
+    throw err;
+  }
+
+  return { sent: true };
+}

--- a/lib/welcome-email.test.js
+++ b/lib/welcome-email.test.js
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  sendWelcomeEmailIfNeeded,
+  WELCOME_SENTINEL_GAME_PK,
+} from "./welcome-email";
+
+function makeSupabaseStub({ insertError = null } = {}) {
+  const insertCalls = [];
+  const deleteCalls = [];
+
+  const fromImpl = (table) => {
+    if (table !== "mlb_sent_notifications") {
+      throw new Error(`Unexpected table: ${table}`);
+    }
+    return {
+      insert: (row) => {
+        insertCalls.push(row);
+        return Promise.resolve({ error: insertError });
+      },
+      delete: () => {
+        const filter = {};
+        const chain = {
+          eq: (col, val) => {
+            filter[col] = val;
+            return chain;
+          },
+          then: (resolve) => {
+            deleteCalls.push(filter);
+            resolve({ error: null });
+          },
+        };
+        return chain;
+      },
+    };
+  };
+
+  return {
+    from: fromImpl,
+    _calls: { insertCalls, deleteCalls },
+  };
+}
+
+describe("sendWelcomeEmailIfNeeded", () => {
+  it("returns no_email when email is missing", async () => {
+    const supabase = makeSupabaseStub();
+    const sendImpl = vi.fn();
+    const result = await sendWelcomeEmailIfNeeded({
+      supabase,
+      userId: "u1",
+      email: null,
+      sendImpl,
+    });
+    expect(result).toEqual({ sent: false, reason: "no_email" });
+    expect(sendImpl).not.toHaveBeenCalled();
+    expect(supabase._calls.insertCalls).toHaveLength(0);
+  });
+
+  it("inserts the sentinel and sends on the first call", async () => {
+    const supabase = makeSupabaseStub();
+    const sendImpl = vi.fn(async () => undefined);
+
+    const result = await sendWelcomeEmailIfNeeded({
+      supabase,
+      userId: "u1",
+      email: "fan@example.com",
+      sendImpl,
+    });
+
+    expect(result).toEqual({ sent: true });
+    expect(supabase._calls.insertCalls).toEqual([
+      { user_id: "u1", game_pk: WELCOME_SENTINEL_GAME_PK },
+    ]);
+    expect(sendImpl).toHaveBeenCalledTimes(1);
+    const [to, subject, html] = sendImpl.mock.calls[0];
+    expect(to).toBe("fan@example.com");
+    expect(subject).toMatch(/welcome/i);
+    expect(html).toContain("You&#39;re in.");
+  });
+
+  it("skips sending when the sentinel already exists (unique-violation 23505)", async () => {
+    const supabase = makeSupabaseStub({
+      insertError: { code: "23505", message: "duplicate key" },
+    });
+    const sendImpl = vi.fn();
+
+    const result = await sendWelcomeEmailIfNeeded({
+      supabase,
+      userId: "u1",
+      email: "fan@example.com",
+      sendImpl,
+    });
+
+    expect(result).toEqual({ sent: false, reason: "already_sent" });
+    expect(sendImpl).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the sentinel when send fails so the next attempt can retry", async () => {
+    const supabase = makeSupabaseStub();
+    const sendImpl = vi.fn(async () => {
+      throw new Error("Brevo 500: boom");
+    });
+
+    await expect(
+      sendWelcomeEmailIfNeeded({
+        supabase,
+        userId: "u1",
+        email: "fan@example.com",
+        sendImpl,
+      })
+    ).rejects.toThrow("Brevo 500: boom");
+
+    expect(supabase._calls.insertCalls).toHaveLength(1);
+    expect(supabase._calls.deleteCalls).toEqual([
+      { user_id: "u1", game_pk: WELCOME_SENTINEL_GAME_PK },
+    ]);
+  });
+
+  it("propagates non-conflict insert errors without sending", async () => {
+    const supabase = makeSupabaseStub({
+      insertError: { code: "42P01", message: "relation missing" },
+    });
+    const sendImpl = vi.fn();
+
+    await expect(
+      sendWelcomeEmailIfNeeded({
+        supabase,
+        userId: "u1",
+        email: "fan@example.com",
+        sendImpl,
+      })
+    ).rejects.toThrow(/relation missing/);
+
+    expect(sendImpl).not.toHaveBeenCalled();
+  });
+});

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -19,7 +19,10 @@ create table public.mlb_game_cache (
   checked_at timestamptz default now() not null
 );
 
--- Sent notification tracking (prevents duplicate emails)
+-- Sent notification tracking (prevents duplicate emails).
+-- Sentinel: game_pk = 0 marks "welcome email sent" for that user (issue #26).
+-- The unique (user_id, game_pk) constraint enforces idempotency atomically,
+-- so two concurrent first-team adds can't both win the welcome-send race.
 create table public.mlb_sent_notifications (
   id uuid default gen_random_uuid() primary key,
   user_id uuid references auth.users(id) on delete cascade not null,


### PR DESCRIPTION
Closes #26.

## Summary

- New `POST /api/welcome` route, called fire-and-forget from `app/dashboard/team-grid.js` after every successful team insert. Session-authenticated (no `CRON_SECRET`).
- New `lib/welcome-email.js#sendWelcomeEmailIfNeeded` helper. Claim-then-send pattern using a sentinel row in `mlb_sent_notifications` with `game_pk = 0`. The existing `unique (user_id, game_pk)` constraint atomically resolves races between concurrent calls; PG `23505` ⇒ already-sent skip; Brevo failure ⇒ sentinel rolled back so a retry can succeed.
- New `buildWelcomeEmailHtml` variant in `lib/email-template.js`: same 520px card visual language as the recap email, brand-green accent (no team color since there's no team yet), one-line welcome, three "how it works" bullets (post-game timing, no scores in subject/preview, link to highlights), CTA back to `/dashboard`, standard unsubscribe + non-affiliation footer.
- No schema migration: sentinel re-uses `mlb_sent_notifications`. Schema and `CLAUDE.md` updated to document the convention.

## Acceptance criteria

- [x] Adding a first team triggers exactly one welcome email (immediately, via the API route — no cron wait).
- [x] Adding additional teams later does **not** re-trigger (sentinel insert hits `23505`).
- [x] Remove-all + re-add does **not** re-trigger (sentinel is never deleted on team removal).
- [x] Visual style matches the cron recap email.

## Test plan

- [x] `npm test` — 82 passing (11 new). Covers template content, links, disclaimer, tip prompt, plus helper happy path / no_email / already_sent / send-failure-rollback / non-conflict insert error.
- [ ] Manual: sign in fresh user, add first team, confirm welcome email arrives.
- [ ] Manual: add a second team, confirm no second welcome.
- [ ] Manual: remove all teams, re-add one, confirm no re-welcome.
- [ ] Manual: visually compare in Gmail/Apple Mail against a recap email.

https://claude.ai/code/session_01S9A8TBZF33VvK84DVUhEmT

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9A8TBZF33VvK84DVUhEmT)_