### PR TITLE
Add forward-to-a-fan line to email footer (#70)

### DIFF
--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -83,6 +83,13 @@ export function buildWelcomeEmailHtml(userId) {
   </td></tr>
   ` : ""}
 
+  <!-- Forward prompt -->
+  <tr><td align="center" style="padding:12px 32px 0 32px;">
+    <p style="margin:0;font-size:13px;color:#52525b;line-height:1.5;">
+      Know a fan who&#39;d like this? Forward them this email or send them <a href="${siteUrl}" style="color:${accent};text-decoration:underline;font-weight:600;">ninthinning.email</a>.
+    </p>
+  </td></tr>
+
   <!-- Footer -->
   <tr><td style="padding:16px 32px 0 32px;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
@@ -111,7 +118,7 @@ export function buildWelcomeEmailHtml(userId) {
 }
 
 export function buildEmailHtml(team, highlightUrl, userId, gameDate) {
-  const siteUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || "https://yourdomain.com";
+  const siteUrl = getSiteUrl();
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
   const tipUrl = process.env.TIP_URL;
   const teamName = team?.name || "Your team";
@@ -177,6 +184,13 @@ export function buildEmailHtml(team, highlightUrl, userId, gameDate) {
     </p>
   </td></tr>
   ` : ""}
+
+  <!-- Forward prompt -->
+  <tr><td align="center" style="padding:12px 32px 0 32px;">
+    <p style="margin:0;font-size:13px;color:#52525b;line-height:1.5;">
+      Know a fan who&#39;d like this? Forward them this email or send them <a href="${siteUrl}" style="color:${teamColor};text-decoration:underline;font-weight:600;">ninthinning.email</a>.
+    </p>
+  </td></tr>
 
   <!-- Footer -->
   <tr><td style="padding:16px 32px 0 32px;">

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -79,6 +79,14 @@ describe("buildEmailHtml", () => {
     expect(html).toContain(`/unsubscribe?token=${USER_ID}`);
     expect(html).toContain(">Unsubscribe<");
   });
+
+  it("includes a forward-to-a-fan prompt linking to the site", () => {
+    process.env.SITE_URL = "https://ninthinning.email";
+    const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE);
+    expect(html).toContain("Forward them this email");
+    expect(html).toContain(">ninthinning.email</a>");
+    expect(html).toContain('href="https://ninthinning.email"');
+  });
 });
 
 describe("buildWelcomeEmailHtml", () => {
@@ -140,5 +148,13 @@ describe("buildWelcomeEmailHtml", () => {
     html = buildWelcomeEmailHtml(USER_ID);
     expect(html).toContain("Tip the developer");
     expect(html).toContain("https://buymeacoffee.com/example");
+  });
+
+  it("includes a forward-to-a-fan prompt linking to the site", () => {
+    process.env.SITE_URL = "https://ninthinning.email";
+    const html = buildWelcomeEmailHtml(USER_ID);
+    expect(html).toContain("Forward them this email");
+    expect(html).toContain(">ninthinning.email</a>");
+    expect(html).toContain('href="https://ninthinning.email"');
   });
 });


### PR DESCRIPTION
Closes #70.

## Summary
- Adds a one-line *"Know a fan who'd like this? Forward them this email or send them ninthinning.email"* prompt to both the recap and welcome email footers in `lib/email-template.js`.
- No tracking, no `?ref=` params, no DB changes — pure word-of-mouth surface, per the issue's scope.
- Drive-by: recap template now uses the existing `getSiteUrl()` helper instead of duplicating the env fallback chain.

## Test plan
- [x] `npm test` — 84 passing (82 → 84 with two new tests asserting the forward line + link render in both templates)
- [ ] Visual spot-check of recap email in Brevo / inbox preview after deploy
- [ ] Visual spot-check of welcome email after deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_015tw5St7k5HGh7bSBfeZhxj)_