### PR TITLE
Differentiate signup vs. sign-in CTAs

### DIFF
--- a/app/login/page.js
+++ b/app/login/page.js
@@ -1,9 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useState } from "react";
 
-export default function LoginPage() {
+function LoginForm() {
+  const searchParams = useSearchParams();
+  const isSignup = searchParams.get("next") === "signup";
   const [email, setEmail] = useState("");
   const [sent, setSent] = useState(false);
   const [error, setError] = useState(null);
@@ -83,10 +86,12 @@ export default function LoginPage() {
           ) : (
             <>
               <h1 className="text-2xl font-bold tracking-tight text-center text-[#f5f1e6]">
-                Sign in
+                {isSignup ? "Get your recaps" : "Sign in"}
               </h1>
               <p className="mt-2 text-center text-sm text-[#a8a299]">
-                Enter your email and we&apos;ll send you a magic link.
+                {isSignup
+                  ? "Enter your email — we'll send a magic link, then you can pick your teams."
+                  : "Enter your email and we'll send you a magic link."}
               </p>
 
               <form onSubmit={handleSubmit} className="mt-6 space-y-3">
@@ -118,5 +123,13 @@ export default function LoginPage() {
         </div>
       </main>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/app/page.js
+++ b/app/page.js
@@ -149,10 +149,10 @@ export default function Home() {
               </p>
               <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center lg:justify-start">
                 <Link
-                  href="/login"
+                  href="/login?next=signup"
                   className="rounded-lg bg-[#c41e3a] px-6 py-3 text-sm font-semibold text-white hover:bg-[#d92645] transition"
                 >
-                  Get my recaps
+                  Pick my teams
                 </Link>
                 <a
                   href="#sample"
@@ -295,10 +295,10 @@ export default function Home() {
           </p>
           <div className="mt-8 flex justify-center">
             <Link
-              href="/login"
+              href="/login?next=signup"
               className="rounded-lg bg-[#c41e3a] px-8 py-3.5 text-sm font-semibold text-white hover:bg-[#d92645] transition"
             >
-              Get my recaps
+              Pick my teams
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Header keeps "Sign in" for returning users; hero and final CTAs become **"Pick my teams"** linking to `/login?next=signup`.
- `/login` reads `?next=signup` and greets first-timers with **"Get your recaps"** + onboarding copy ("…then you can pick your teams") instead of the returning-user "Sign in" heading.
- Wraps `LoginForm` in `Suspense` since `useSearchParams` requires it.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` — 84/84 pass
- [ ] Visit `/` — header still says "Sign in"; hero + final CTAs say "Pick my teams"
- [ ] Click a body CTA → `/login?next=signup` shows "Get your recaps" heading
- [ ] Visit `/login` directly (or via header) → shows "Sign in" heading
- [ ] Magic link still sends and auth flow works end-to-end

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ld7owbdFMB1xF57CWKftM9)_