### PR TITLE
Add spoiler-safe standings to recap email (#148)

### DIFF
--- a/lib/cron-jobs.js
+++ b/lib/cron-jobs.js
@@ -10,6 +10,8 @@ import {
   extractScheduledGames,
   computeExpectedFinish,
   getEtTodayDate,
+  fetchStandings,
+  extractTeamStanding,
 } from "@/lib/mlb";
 import { buildEmailHtml } from "@/lib/email-template";
 import { sendEmail } from "@/lib/brevo";
@@ -20,6 +22,16 @@ const EARLY_BOUND_MS = 30 * 60 * 1000;
 const LATE_BOUND_MS = 2.5 * 60 * 60 * 1000;
 
 const STALE_WAKE_HOURS = 36;
+
+function previousDateStr(dateStr) {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() - 1);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getUTCDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
 
 function isInMlbSeason() {
   const month = parseInt(
@@ -213,6 +225,25 @@ export async function runMainCron({ supabase, emailsPaused = false } = {}) {
     let emailsSent = 0;
     const skipped = [];
 
+    // Spoiler-safe standings snapshot: for each unique game date, fetch the
+    // standings as of the day before first pitch (issue #148). One MLB API
+    // call per date covers all 30 teams for that date.
+    const standingsByDate = new Map();
+    const uniqueGameDates = [...new Set(newGames.map((g) => g.gameDate))];
+    for (const dateStr of uniqueGameDates) {
+      try {
+        const snapshotDate = previousDateStr(dateStr);
+        const standings = await fetchStandings(snapshotDate);
+        standingsByDate.set(dateStr, standings);
+      } catch (err) {
+        console.warn(
+          `Standings fetch failed for ${dateStr} (continuing without standings):`,
+          err.message
+        );
+        standingsByDate.set(dateStr, null);
+      }
+    }
+
     for (const game of newGames) {
       const { data: subscribers } = await supabase
         .from("mlb_user_teams")
@@ -254,7 +285,9 @@ export async function runMainCron({ supabase, emailsPaused = false } = {}) {
         const team = TEAMS_BY_ID[game.teamId];
         const teamName = team?.name || `Team ${game.teamId}`;
         const subject = `${teamName} Highlights — ${formatDisplayDate(game.gameDate)}`;
-        const html = buildEmailHtml(team, game.highlightUrl, userId, game.gameDate);
+        const standings = standingsByDate.get(game.gameDate);
+        const standing = standings ? extractTeamStanding(standings, game.teamId) : null;
+        const html = buildEmailHtml(team, game.highlightUrl, userId, game.gameDate, standing);
 
         try {
           await sendEmail(email, subject, html);

--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -133,7 +133,51 @@ export function buildWelcomeEmailHtml(userId) {
 </html>`;
 }
 
-export function buildEmailHtml(team, highlightUrl, userId, gameDate) {
+// Spoiler-safe standings strip (#148). `standing` is the snapshot from the day
+// before first pitch, so the rendered numbers cannot reveal the result of the
+// game being recapped. Returns an empty string when no usable data exists.
+function renderStandingsStrip(standing, accentColor) {
+  if (!standing) return "";
+  const { divisionName, divisionRank, wins, losses, gamesBack, wildCardRank, wildCardGamesBack } =
+    standing;
+
+  if (wins === null || losses === null || !divisionRank) return "";
+
+  const divOrdinal = ordinal(divisionRank);
+  const gbLabel = gamesBack && gamesBack !== "-" ? `${gamesBack} GB` : "1st in division";
+  const divLine =
+    divisionRank === 1
+      ? `${divisionName} &middot; <strong>1st</strong> &middot; ${wins}&ndash;${losses}`
+      : `${divisionName} &middot; <strong>${divOrdinal}</strong> &middot; ${wins}&ndash;${losses} &middot; ${gbLabel}`;
+
+  let wcLine = "";
+  if (divisionRank !== 1 && wildCardRank) {
+    const wcOrdinal = ordinal(wildCardRank);
+    const wcSuffix =
+      wildCardGamesBack && wildCardGamesBack !== "-"
+        ? ` (${wildCardGamesBack})`
+        : "";
+    wcLine = `<div style="margin-top:4px;font-size:13px;color:#52525b;">Wild Card: <strong>${wcOrdinal}</strong>${wcSuffix}</div>`;
+  }
+
+  return `
+  <!-- Standings strip (spoiler-safe: as of the day before first pitch) -->
+  <tr><td style="padding:16px 32px 0 32px;">
+    <div style="border-left:3px solid ${accentColor};padding:8px 12px;background-color:rgba(0,0,0,0.02);border-radius:0 4px 4px 0;">
+      <div style="font-size:11px;font-weight:700;letter-spacing:0.5px;color:#71717a;text-transform:uppercase;margin-bottom:4px;">Standings entering today</div>
+      <div style="font-size:14px;color:#3f3f46;">${divLine}</div>
+      ${wcLine}
+    </div>
+  </td></tr>`;
+}
+
+function ordinal(n) {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+export function buildEmailHtml(team, highlightUrl, userId, gameDate, standing = null) {
   const siteUrl = getSiteUrl();
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
   const tipUrl = process.env.TIP_URL;
@@ -141,6 +185,7 @@ export function buildEmailHtml(team, highlightUrl, userId, gameDate) {
   const teamColor = team?.color || "#2563eb";
   const teamAbbr = team?.abbr || "";
   const displayDate = formatDisplayDate(gameDate);
+  const standingsHtml = renderStandingsStrip(standing, teamColor);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -177,6 +222,8 @@ export function buildEmailHtml(team, highlightUrl, userId, gameDate) {
     <h1 style="margin:0;font-family:'General Sans','Hanken Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:24px;font-weight:600;color:#1a1d1c;line-height:1.3;letter-spacing:-0.02em;">${teamName} highlights are ready</h1>
     <p style="margin:8px 0 0 0;font-size:15px;color:#52525b;line-height:1.5;">Your spoiler-free game recap is waiting for you.</p>
   </td></tr>
+
+  ${standingsHtml}
 
   <!-- CTA Button -->
   <tr><td style="padding:24px 32px 0 32px;">

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -87,6 +87,84 @@ describe("buildEmailHtml", () => {
     expect(html).toContain(">ninthinning.email</a>");
     expect(html).toContain('href="https://ninthinning.email"');
   });
+
+  describe("standings strip", () => {
+    it("omits the standings block when no standing is provided", () => {
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE);
+      expect(html).not.toContain("Standings entering today");
+      expect(html).not.toContain("Wild Card");
+    });
+
+    it("renders division rank, record, GB, and WC line for a wild-card team", () => {
+      const standing = {
+        divisionName: "AL East",
+        divisionRank: 2,
+        wins: 54,
+        losses: 35,
+        gamesBack: "2.0",
+        wildCardRank: 1,
+        wildCardGamesBack: "+6.0",
+      };
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, standing);
+      expect(html).toContain("Standings entering today");
+      expect(html).toContain("AL East");
+      expect(html).toContain("<strong>2nd</strong>");
+      expect(html).toContain("54&ndash;35");
+      expect(html).toContain("2.0 GB");
+      expect(html).toContain("Wild Card:");
+      expect(html).toContain("<strong>1st</strong>");
+      expect(html).toContain("(+6.0)");
+    });
+
+    it("drops the wild card line for a division leader", () => {
+      const standing = {
+        divisionName: "AL East",
+        divisionRank: 1,
+        wins: 55,
+        losses: 32,
+        gamesBack: "-",
+        wildCardRank: null,
+        wildCardGamesBack: "-",
+      };
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, standing);
+      expect(html).toContain("Standings entering today");
+      expect(html).toContain("<strong>1st</strong>");
+      expect(html).toContain("55&ndash;32");
+      expect(html).not.toContain("Wild Card:");
+    });
+
+    it("omits the strip when wins/losses/rank are missing", () => {
+      const standing = {
+        divisionName: "AL East",
+        divisionRank: null,
+        wins: null,
+        losses: null,
+        gamesBack: null,
+        wildCardRank: null,
+        wildCardGamesBack: null,
+      };
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, standing);
+      expect(html).not.toContain("Standings entering today");
+    });
+
+    it("renders the strip above the Watch Highlights CTA so it can't spoil the result", () => {
+      const standing = {
+        divisionName: "AL East",
+        divisionRank: 2,
+        wins: 54,
+        losses: 35,
+        gamesBack: "2.0",
+        wildCardRank: 1,
+        wildCardGamesBack: "+6.0",
+      };
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, standing);
+      const standingsIdx = html.indexOf("Standings entering today");
+      const ctaIdx = html.indexOf("Watch Highlights");
+      expect(standingsIdx).toBeGreaterThan(-1);
+      expect(ctaIdx).toBeGreaterThan(-1);
+      expect(standingsIdx).toBeLessThan(ctaIdx);
+    });
+  });
 });
 
 describe("buildWelcomeEmailHtml", () => {

--- a/lib/mlb.js
+++ b/lib/mlb.js
@@ -112,6 +112,86 @@ export function getDatesToCheck() {
   return [today, yesterday, twoDaysAgo];
 }
 
+// Standings: the MLB Stats API returns historical standings when given a `date`
+// param in MM/DD/YYYY form. For spoiler-safety we always query the day BEFORE
+// today's first pitch (ET), so the rendered "as fans walked in" snapshot can't
+// reflect the game we're about to recap. See issue #148.
+export async function fetchStandings(dateStr) {
+  const apiDate = toMlbDateParam(dateStr);
+  const season = dateStr.slice(0, 4);
+  const url = `https://statsapi.mlb.com/api/v1/standings?leagueId=103,104&season=${season}&date=${apiDate}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`MLB standings API ${res.status} for date ${dateStr}`);
+  }
+  return res.json();
+}
+
+function toMlbDateParam(dateStr) {
+  const [y, m, d] = dateStr.split("-");
+  return `${m}/${d}/${y}`;
+}
+
+// AL = 103, NL = 104. Division IDs are stable across seasons.
+const DIVISION_NAMES = {
+  200: "AL West",
+  201: "AL East",
+  202: "AL Central",
+  203: "AL West",
+  204: "NL West",
+  205: "NL East",
+  // Stats API uses both 202/200 and 203 historically — keep a defensive map.
+};
+const DIVISION_NAMES_FALLBACK = {
+  AL_E: "AL East",
+  AL_C: "AL Central",
+  AL_W: "AL West",
+  NL_E: "NL East",
+  NL_C: "NL Central",
+  NL_W: "NL West",
+};
+
+export function extractTeamStanding(standings, teamId) {
+  const records = standings?.records;
+  if (!Array.isArray(records) || records.length === 0) return null;
+
+  for (const rec of records) {
+    const teams = rec.teamRecords || [];
+    const match = teams.find((t) => t?.team?.id === teamId);
+    if (!match) continue;
+
+    const divisionName =
+      rec.division?.name ||
+      DIVISION_NAMES[rec.division?.id] ||
+      DIVISION_NAMES_FALLBACK[rec.division?.abbreviation] ||
+      "Division";
+
+    return {
+      divisionName: shortenDivisionName(divisionName),
+      divisionRank: toIntOrNull(match.divisionRank),
+      wins: match.wins ?? null,
+      losses: match.losses ?? null,
+      gamesBack: match.gamesBack ?? null,
+      wildCardRank: toIntOrNull(match.wildCardRank),
+      wildCardGamesBack: match.wildCardGamesBack ?? null,
+    };
+  }
+  return null;
+}
+
+function toIntOrNull(v) {
+  if (v === null || v === undefined || v === "") return null;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+// "American League East" → "AL East". MLB API sometimes returns the long form.
+function shortenDivisionName(name) {
+  return name
+    .replace(/^American League\s+/i, "AL ")
+    .replace(/^National League\s+/i, "NL ");
+}
+
 export function formatDisplayDate(dateStr) {
   const [year, month, day] = dateStr.split("-").map(Number);
   const date = new Date(year, month - 1, day);

--- a/lib/mlb.test.js
+++ b/lib/mlb.test.js
@@ -10,6 +10,8 @@ import {
   getDatesToCheck,
   getEtTodayDate,
   formatDisplayDate,
+  fetchStandings,
+  extractTeamStanding,
   EXPECTED_GAME_DURATION_HOURS,
 } from "./mlb";
 
@@ -279,6 +281,126 @@ describe("getEtTodayDate", () => {
     expect(getEtTodayDate(new Date("2026-05-02T03:00:00Z"))).toBe("2026-05-01");
     // 2026-05-02 17:00 UTC = 2026-05-02 13:00 EDT
     expect(getEtTodayDate(new Date("2026-05-02T17:00:00Z"))).toBe("2026-05-02");
+  });
+});
+
+describe("fetchStandings", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("queries the MLB standings endpoint with the date in MM/DD/YYYY", async () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ records: [] }) });
+
+    await fetchStandings("2024-07-04");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://statsapi.mlb.com/api/v1/standings?leagueId=103,104&season=2024&date=07/04/2024"
+    );
+  });
+
+  it("throws when the response is not ok", async () => {
+    fetch.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+
+    await expect(fetchStandings("2024-07-04")).rejects.toThrow(
+      "MLB standings API 500 for date 2024-07-04"
+    );
+  });
+});
+
+describe("extractTeamStanding", () => {
+  const fixture = {
+    records: [
+      {
+        division: { id: 201, name: "American League East" },
+        teamRecords: [
+          {
+            team: { id: 110, name: "Baltimore Orioles" },
+            wins: 55,
+            losses: 32,
+            gamesBack: "-",
+            divisionRank: "1",
+            wildCardRank: null,
+            wildCardGamesBack: "-",
+          },
+          {
+            team: { id: 147, name: "New York Yankees" },
+            wins: 54,
+            losses: 35,
+            gamesBack: "2.0",
+            divisionRank: "2",
+            wildCardRank: "1",
+            wildCardGamesBack: "+6.0",
+          },
+          {
+            team: { id: 111, name: "Boston Red Sox" },
+            wins: 47,
+            losses: 40,
+            gamesBack: "8.0",
+            divisionRank: "3",
+            wildCardRank: "3",
+            wildCardGamesBack: "-",
+          },
+        ],
+      },
+    ],
+  };
+
+  it("returns a division leader's record with null wildCardRank", () => {
+    const s = extractTeamStanding(fixture, 110);
+    expect(s).toEqual({
+      divisionName: "AL East",
+      divisionRank: 1,
+      wins: 55,
+      losses: 32,
+      gamesBack: "-",
+      wildCardRank: null,
+      wildCardGamesBack: "-",
+    });
+  });
+
+  it("returns a wild-card team's record with rank and games-back string", () => {
+    const s = extractTeamStanding(fixture, 147);
+    expect(s.divisionRank).toBe(2);
+    expect(s.wildCardRank).toBe(1);
+    expect(s.wildCardGamesBack).toBe("+6.0");
+    expect(s.gamesBack).toBe("2.0");
+  });
+
+  it("returns null when the team is not in any record", () => {
+    expect(extractTeamStanding(fixture, 999)).toBeNull();
+  });
+
+  it("returns null on an empty or missing standings payload (off-season guard)", () => {
+    expect(extractTeamStanding({ records: [] }, 147)).toBeNull();
+    expect(extractTeamStanding({}, 147)).toBeNull();
+    expect(extractTeamStanding(null, 147)).toBeNull();
+  });
+
+  it("shortens 'American League' / 'National League' to AL / NL", () => {
+    const nl = {
+      records: [
+        {
+          division: { id: 205, name: "National League East" },
+          teamRecords: [
+            {
+              team: { id: 121 },
+              wins: 50,
+              losses: 40,
+              gamesBack: "3.0",
+              divisionRank: "2",
+              wildCardRank: "2",
+              wildCardGamesBack: "+1.0",
+            },
+          ],
+        },
+      ],
+    };
+    expect(extractTeamStanding(nl, 121).divisionName).toBe("NL East");
   });
 });
 


### PR DESCRIPTION
Closes #148.

## Summary

Adds a compact "Standings entering today" strip above the Watch Highlights CTA, showing division rank, record, games-back, and (when applicable) wild-card position. Spoiler-safe by construction: the snapshot is queried for the **day before first pitch (ET)**, so the rendered numbers never reflect the result of the game being recapped.

## How it stays spoiler-safe

The MLB Stats API `/api/v1/standings` endpoint accepts a `date` param in `MM/DD/YYYY` form and returns historical standings (verified live against `07/04/2024`, `09/29/2024`, `04/01/2024`). For each completed game keyed by `gameDate`, the cron computes `gameDate - 1` and fetches standings as of that morning. One API call per unique game date covers all 30 teams.

## Implementation

- `lib/mlb.js` &mdash; `fetchStandings(dateStr)` (converts `YYYY-MM-DD` &rarr; `MM/DD/YYYY`) and `extractTeamStanding(standings, teamId)` returning `{ divisionName, divisionRank, wins, losses, gamesBack, wildCardRank, wildCardGamesBack }` or `null`.
- `lib/cron-jobs.js` &mdash; pre-fetches standings once per unique game date before the send loop. Failures are non-fatal; the email goes out without the strip.
- `lib/email-template.js` &mdash; new `renderStandingsStrip` helper. Division leaders get a single line ("AL East &middot; **1st** &middot; 55&ndash;32"); non-leaders get a second line for wild-card position. Renders nothing when `standing` is missing or the fields are empty (off-season / pre-season edge cases).

## Field quirks handled

- `gamesBack` is a string (`"-"` for leaders, e.g. `"2.0"` otherwise).
- `wildCardRank` is `null` for division leaders &mdash; we skip the WC line.
- `wildCardGamesBack` can be `"-"`, `"+X.0"`, or `"X.0"` &mdash; passed through verbatim in parentheses.
- "American League East" &rarr; "AL East" (the API occasionally returns the long form).

## Test plan

- [x] `npm test` &mdash; 96/96 passing (12 new tests covering the new helpers and rendering).
- [x] `npm run build` &mdash; clean.
- [ ] Send a test recap to a real inbox (Gmail web + Apple Mail) and eyeball the strip.
- [ ] Confirm off-season behavior: trigger a send during the All-Star break or before opening day &mdash; standings block should be absent, not broken.
- [ ] Spot-check a real cron run: verify exactly one `/api/v1/standings` call per unique `game_date` in worker logs.

## Out of scope

- Doubleheader game 2 (would ideally show post-game-1 standings &mdash; not granular at the API level; same pre-game-of-the-day snapshot is used for both).
- Historical backfill of past emails.

https://claude.ai/code/session_01DqToXFzH1R6qegdNwFbMcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqToXFzH1R6qegdNwFbMcY)_