### PR TITLE
Add /admin &#34;Resend latest recap to me&#34; button (#150)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,12 +215,13 @@ Failure modes worth knowing:
 
 When you need to manually kick the cron — e.g. the daily scheduler missed a tick, or a *every-15-min run silently early-returned during a deploy window — the primary recovery path is the **/admin** page, not curl + bearer token.
 
-Two buttons on `/admin`:
+Three buttons on `/admin`:
 
 - **Run daily scheduler now** — invokes the same code path as `GET /api/cron/schedule` (populates `mlb_cron_schedule` for today).
 - **Run main cron now** — invokes the same code path as `GET /api/cron` (checks for completed games and sends emails).
+- **Resend latest recap to me** (#150) — re-renders the admin's most recent recap with the current `buildEmailHtml` and sends it back to `ADMIN_EMAIL` with a `[TEST]` subject prefix. Uses `lib/resend-recap.js`, which prefers the latest `mlb_sent_notifications` row for the admin (excluding the welcome sentinel `game_pk = 0`) and falls back to the most recent `mlb_game_cache` row with a `highlight_url`. Standings are re-fetched the same way `runMainCron` does so template changes that depend on `extractTeamStanding` are exercised. Does **not** write to `mlb_sent_notifications` (so it won't block future real sends or pollute analytics) and respects `EMAILS_PAUSED`.
 
-Both run as Next.js Server Actions. Auth is the existing admin session check: the action calls `assertAdmin()` server-side (re-checks `auth.getUser()` and `ADMIN_EMAIL`) before doing any work — `notFound()` on the page hides the buttons but is **not** the security boundary. No `CRON_SECRET` is required, since auth is via the user session, not a bearer token. The shared cron logic lives in `lib/cron-jobs.js` (`runMainCron` and `runScheduler`); both the route handlers and the server actions call into it.
+All run as Next.js Server Actions. Auth is the existing admin session check: the action calls `assertAdmin()` server-side (re-checks `auth.getUser()` and `ADMIN_EMAIL`) before doing any work — `notFound()` on the page hides the buttons but is **not** the security boundary. No `CRON_SECRET` is required, since auth is via the user session, not a bearer token. The shared cron logic lives in `lib/cron-jobs.js` (`runMainCron` and `runScheduler`); both the route handlers and the server actions call into it.
 
 Recovery time goes from ~10 min (rotate `CRON_SECRET`, then DevTools fetch) to ~30 sec (open `/admin`, click button). The 2026-05-02 incident in `INCIDENT.md` is the canonical example of why this matters: not having `CRON_SECRET` saved blocked recovery for the first ~10 min.
 

--- a/app/admin/actions.js
+++ b/app/admin/actions.js
@@ -3,6 +3,7 @@
 import { createClient } from "@/lib/supabase-server";
 import { createAdminClient } from "@/lib/supabase-admin";
 import { runMainCron, runScheduler } from "@/lib/cron-jobs";
+import { resendLatestRecap } from "@/lib/resend-recap";
 
 // Defense-in-depth: re-check the admin email server-side. Page-level
 // notFound() only hides UI; a non-admin who guesses the action endpoint
@@ -18,7 +19,7 @@ async function assertAdmin() {
   if (!process.env.ADMIN_EMAIL || user.email !== process.env.ADMIN_EMAIL) {
     return { ok: false, error: "Forbidden" };
   }
-  return { ok: true };
+  return { ok: true, user };
 }
 
 export async function runSchedulerAction(_prevState, _formData) {
@@ -54,4 +55,50 @@ export async function runMainCronAction(_prevState, _formData) {
     errors: body.errors,
     ranAt: new Date().toISOString(),
   };
+}
+
+export async function resendLatestRecapAction(_prevState, _formData) {
+  const ranAt = new Date().toISOString();
+  const auth = await assertAdmin();
+  if (!auth.ok) {
+    return { ok: false, message: auth.error, ranAt };
+  }
+
+  if (process.env.EMAILS_PAUSED === "true") {
+    return {
+      ok: false,
+      message: "Emails paused via kill switch",
+      ranAt,
+    };
+  }
+
+  const supabase = createAdminClient();
+  try {
+    const result = await resendLatestRecap({
+      supabase,
+      adminUserId: auth.user.id,
+      adminEmail: auth.user.email,
+    });
+    if (!result.ok) {
+      return {
+        ok: false,
+        message:
+          result.reason === "no_recaps_found"
+            ? "No recaps found to resend"
+            : result.reason || "Resend failed",
+        ranAt,
+      };
+    }
+    return {
+      ok: true,
+      message: `Resent recap for game ${result.gamePk} (${result.gameDate}) to ${auth.user.email}`,
+      ranAt,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      message: `Resend failed: ${err.message}`,
+      ranAt,
+    };
+  }
 }

--- a/app/admin/actions.test.js
+++ b/app/admin/actions.test.js
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoisted mock state — vi.mock factory bodies are hoisted above imports, so the
+// shared state has to live inside vi.hoisted() to be in-scope when the factory
+// runs.
+const hoisted = vi.hoisted(() => ({
+  authUser: null,
+  adminSupabase: null,
+  sendEmailImpl: vi.fn(),
+  fetchStandingsImpl: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () => ({ data: { user: hoisted.authUser } }),
+    },
+  }),
+}));
+
+vi.mock("@/lib/supabase-admin", () => ({
+  createAdminClient: () => hoisted.adminSupabase,
+}));
+
+vi.mock("@/lib/brevo", () => ({
+  sendEmail: (...args) => hoisted.sendEmailImpl(...args),
+  SENDER_NAME: "Ninth Inning Email",
+}));
+
+vi.mock("@/lib/mlb", async () => {
+  const actual = await vi.importActual("@/lib/mlb");
+  return {
+    ...actual,
+    fetchStandings: (...args) => hoisted.fetchStandingsImpl(...args),
+  };
+});
+
+// Imported after vi.mock so the mocked deps resolve.
+const { resendLatestRecapAction } = await import("./actions");
+
+// Builds a chainable Supabase query stub. Each call to `.from(table)` returns a
+// fresh query object whose terminal calls (`.maybeSingle()`, `.single()`,
+// awaiting directly) resolve to the script entry registered for that table.
+function makeSupabaseStub(script) {
+  const calls = [];
+
+  function makeQuery(table) {
+    const entry = script[table];
+    if (!entry) {
+      throw new Error(`No script entry for table "${table}"`);
+    }
+    const result = entry.shift ? entry.shift() : entry;
+
+    const query = {
+      _table: table,
+      select() {
+        return query;
+      },
+      eq() {
+        return query;
+      },
+      gt() {
+        return query;
+      },
+      not() {
+        return query;
+      },
+      order() {
+        return query;
+      },
+      limit() {
+        return query;
+      },
+      maybeSingle() {
+        return Promise.resolve(result);
+      },
+      single() {
+        return Promise.resolve(result);
+      },
+      then(resolve, reject) {
+        return Promise.resolve(result).then(resolve, reject);
+      },
+    };
+
+    return query;
+  }
+
+  return {
+    from(table) {
+      calls.push(table);
+      return makeQuery(table);
+    },
+    _calls: calls,
+  };
+}
+
+const ADMIN_EMAIL = "admin@example.com";
+const ADMIN_ID = "admin-user-id";
+
+beforeEach(() => {
+  process.env.ADMIN_EMAIL = ADMIN_EMAIL;
+  delete process.env.EMAILS_PAUSED;
+  hoisted.authUser = { id: ADMIN_ID, email: ADMIN_EMAIL };
+  hoisted.sendEmailImpl = vi.fn(async () => undefined);
+  hoisted.fetchStandingsImpl = vi.fn(async () => ({ records: [] }));
+  hoisted.adminSupabase = null;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resendLatestRecapAction", () => {
+  it("rejects a non-admin caller without sending", async () => {
+    hoisted.authUser = { id: "other-id", email: "imposter@example.com" };
+    hoisted.adminSupabase = makeSupabaseStub({});
+
+    const result = await resendLatestRecapAction(null, null);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toBe("Forbidden");
+    expect(hoisted.sendEmailImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear message when the admin has no prior recaps and the cache is empty", async () => {
+    hoisted.adminSupabase = makeSupabaseStub({
+      mlb_sent_notifications: { data: null, error: null },
+      mlb_game_cache: { data: null, error: null },
+    });
+
+    const result = await resendLatestRecapAction(null, null);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toBe("No recaps found to resend");
+    expect(hoisted.sendEmailImpl).not.toHaveBeenCalled();
+  });
+
+  it("re-renders and sends the admin's most recent recap with a [TEST] prefix", async () => {
+    // Yankees (team 147) — used to assert the team name lands in the HTML.
+    const gamePk = 778899;
+    hoisted.adminSupabase = makeSupabaseStub({
+      mlb_sent_notifications: {
+        data: { game_pk: gamePk, sent_at: "2026-05-10T03:00:00Z" },
+        error: null,
+      },
+      mlb_game_cache: {
+        data: {
+          game_pk: gamePk,
+          team_id: 147,
+          game_date: "2026-05-09",
+          highlight_url: "https://mlb.com/video/yankees-recap",
+        },
+        error: null,
+      },
+    });
+
+    const result = await resendLatestRecapAction(null, null);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/778899/);
+    expect(hoisted.sendEmailImpl).toHaveBeenCalledTimes(1);
+    const [to, subject, html] = hoisted.sendEmailImpl.mock.calls[0];
+    expect(to).toBe(ADMIN_EMAIL);
+    expect(subject.startsWith("[TEST] ")).toBe(true);
+    expect(subject).toContain("New York Yankees Highlights");
+    expect(html).toContain("New York Yankees");
+    expect(html).toContain("https://mlb.com/video/yankees-recap");
+  });
+
+  it("is blocked when EMAILS_PAUSED is set", async () => {
+    process.env.EMAILS_PAUSED = "true";
+    hoisted.adminSupabase = makeSupabaseStub({});
+
+    const result = await resendLatestRecapAction(null, null);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/paused/i);
+    expect(hoisted.sendEmailImpl).not.toHaveBeenCalled();
+  });
+});

--- a/app/admin/break-glass.js
+++ b/app/admin/break-glass.js
@@ -1,7 +1,11 @@
 "use client";
 
 import { useActionState } from "react";
-import { runSchedulerAction, runMainCronAction } from "./actions";
+import {
+  runSchedulerAction,
+  runMainCronAction,
+  resendLatestRecapAction,
+} from "./actions";
 
 const INITIAL = { ok: null, message: null, errors: null, ranAt: null };
 
@@ -21,6 +25,10 @@ export default function BreakGlass() {
         <BreakGlassButton
           label="Run main cron now"
           action={runMainCronAction}
+        />
+        <BreakGlassButton
+          label="Resend latest recap to me"
+          action={resendLatestRecapAction}
         />
       </div>
     </div>

--- a/lib/resend-recap.js
+++ b/lib/resend-recap.js
@@ -1,0 +1,118 @@
+import { TEAMS_BY_ID } from "@/lib/teams";
+import {
+  fetchStandings,
+  extractTeamStanding,
+  formatDisplayDate,
+} from "@/lib/mlb";
+import { buildEmailHtml } from "@/lib/email-template";
+import { sendEmail } from "@/lib/brevo";
+
+function previousDateStr(dateStr) {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() - 1);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getUTCDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
+// Re-render and re-send the admin's most recent recap. Used by the /admin
+// break-glass "Resend latest recap to me" button (issue #150) to QA template
+// changes in a real inbox without waiting for a real game.
+//
+// Lookup order:
+//   1. Latest mlb_sent_notifications row for adminUserId (excluding the
+//      welcome sentinel, game_pk = 0), joined to mlb_game_cache.
+//   2. Fallback: latest mlb_game_cache row that has a highlight_url, regardless
+//      of whether the admin was subscribed.
+//
+// Does NOT write to mlb_sent_notifications — this is a test send. Subject is
+// prefixed `[TEST]` so it's obvious in the inbox.
+export async function resendLatestRecap({
+  supabase,
+  adminUserId,
+  adminEmail,
+  sendImpl = sendEmail,
+  fetchStandingsImpl = fetchStandings,
+}) {
+  let gamePk = null;
+  let teamId = null;
+  let gameDate = null;
+  let highlightUrl = null;
+  let source = null;
+
+  const { data: latestSent, error: sentErr } = await supabase
+    .from("mlb_sent_notifications")
+    .select("game_pk, sent_at")
+    .eq("user_id", adminUserId)
+    .gt("game_pk", 0)
+    .order("sent_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (sentErr) {
+    throw new Error(`Failed to read mlb_sent_notifications: ${sentErr.message}`);
+  }
+
+  if (latestSent?.game_pk) {
+    const { data: cache, error: cacheErr } = await supabase
+      .from("mlb_game_cache")
+      .select("game_pk, team_id, game_date, highlight_url")
+      .eq("game_pk", latestSent.game_pk)
+      .maybeSingle();
+    if (cacheErr) {
+      throw new Error(`Failed to read mlb_game_cache: ${cacheErr.message}`);
+    }
+    if (cache?.highlight_url) {
+      gamePk = cache.game_pk;
+      teamId = cache.team_id;
+      gameDate = cache.game_date;
+      highlightUrl = cache.highlight_url;
+      source = "sent_notifications";
+    }
+  }
+
+  if (!highlightUrl) {
+    const { data: cache, error: cacheErr } = await supabase
+      .from("mlb_game_cache")
+      .select("game_pk, team_id, game_date, highlight_url")
+      .not("highlight_url", "is", null)
+      .order("checked_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (cacheErr) {
+      throw new Error(`Failed to read mlb_game_cache: ${cacheErr.message}`);
+    }
+    if (cache?.highlight_url) {
+      gamePk = cache.game_pk;
+      teamId = cache.team_id;
+      gameDate = cache.game_date;
+      highlightUrl = cache.highlight_url;
+      source = "game_cache_fallback";
+    }
+  }
+
+  if (!highlightUrl) {
+    return { ok: false, reason: "no_recaps_found" };
+  }
+
+  let standing = null;
+  try {
+    const standings = await fetchStandingsImpl(previousDateStr(gameDate));
+    standing = extractTeamStanding(standings, teamId);
+  } catch (err) {
+    console.warn(
+      `resend-recap: standings fetch failed for ${gameDate} (continuing without):`,
+      err.message
+    );
+  }
+
+  const team = TEAMS_BY_ID[teamId];
+  const teamName = team?.name || `Team ${teamId}`;
+  const subject = `[TEST] ${teamName} Highlights — ${formatDisplayDate(gameDate)}`;
+  const html = buildEmailHtml(team, highlightUrl, adminUserId, gameDate, standing);
+
+  await sendImpl(adminEmail, subject, html);
+
+  return { ok: true, gamePk, teamId, gameDate, source };
+}


### PR DESCRIPTION
Closes #150.

## Summary

- New break-glass button on `/admin` that re-renders the admin's most recent recap through the production `buildEmailHtml` + `sendEmail` path and sends it back to `ADMIN_EMAIL` with a `[TEST]` subject prefix. Lets us QA template changes (e.g. the standings strip from #148) in a real inbox without waiting for a live game.
- Lookup is admin-first: latest `mlb_sent_notifications` row for the admin (excluding the welcome sentinel `game_pk = 0`), joined to `mlb_game_cache`. Falls back to the most recent `mlb_game_cache` row with a `highlight_url` when the admin has no prior recaps.
- Standings are re-fetched via `fetchStandings(previousDateStr(gameDate))` + `extractTeamStanding` — same code path as `runMainCron`, so template changes that depend on standings are exercised.
- Does **not** write to `mlb_sent_notifications` (test send, not a real notification), and is blocked by `EMAILS_PAUSED` since it shares the `sendEmail` path.
- Auth reuses the existing `assertAdmin()` (extended to return the signed-in user so the helper can address the email).

## Files

- `lib/resend-recap.js` — new helper with injectable deps for unit testing.
- `app/admin/actions.js` — new `resendLatestRecapAction` server action.
- `app/admin/break-glass.js` — third button in the existing grid.
- `app/admin/actions.test.js` — 4 tests: non-admin rejection, no-recaps message, happy-path send (asserts `[TEST]` prefix + team name in body + admin recipient), and `EMAILS_PAUSED` blocking.
- `CLAUDE.md` — updated the break-glass section.

## Test plan

- [x] `npm test` — 100/100 passing locally
- [ ] Manual: open `/admin` as the admin user, click **Resend latest recap to me**, confirm `[TEST] …` email arrives and renders the current template
- [ ] Manual: set `EMAILS_PAUSED=true`, click the button, confirm the form shows "Emails paused via kill switch" and no email is sent
- [ ] Manual: confirm no new row appears in `mlb_sent_notifications` after a test send (so it doesn't block future real sends)

https://claude.ai/code/session_01CfCWug8vNhb5yB8KYuxHtr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfCWug8vNhb5yB8KYuxHtr)_