### PR TITLE
Move standings strip below the Watch Highlights CTA (#152)

### DIFF
--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -223,8 +223,6 @@ export function buildEmailHtml(team, highlightUrl, userId, gameDate, standing = 
     <p style="margin:8px 0 0 0;font-size:15px;color:#52525b;line-height:1.5;">Your spoiler-free game recap is waiting for you.</p>
   </td></tr>
 
-  ${standingsHtml}
-
   <!-- CTA Button -->
   <tr><td style="padding:24px 32px 0 32px;">
     <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
@@ -237,6 +235,7 @@ export function buildEmailHtml(team, highlightUrl, userId, gameDate, standing = 
     </table>
   </td></tr>
 
+  ${standingsHtml}
   <!-- Footer divider -->
   <tr><td style="padding:32px 32px 0 32px;">
     <hr style="margin:0;border:none;border-top:1px solid #e4e4e7;">

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -147,7 +147,7 @@ describe("buildEmailHtml", () => {
       expect(html).not.toContain("Standings entering today");
     });
 
-    it("renders the strip above the Watch Highlights CTA so it can't spoil the result", () => {
+    it("renders the strip below the Watch Highlights CTA", () => {
       const standing = {
         divisionName: "AL East",
         divisionRank: 2,
@@ -162,7 +162,7 @@ describe("buildEmailHtml", () => {
       const ctaIdx = html.indexOf("Watch Highlights");
       expect(standingsIdx).toBeGreaterThan(-1);
       expect(ctaIdx).toBeGreaterThan(-1);
-      expect(standingsIdx).toBeLessThan(ctaIdx);
+      expect(standingsIdx).toBeGreaterThan(ctaIdx);
     });
   });
 });


### PR DESCRIPTION
Closes #152.

## Summary

- Move the `${standingsHtml}` interpolation in `buildEmailHtml` from above the Watch Highlights CTA to immediately below it.
- Flip the corresponding ordering assertion in `email-template.test.js` (`standingsIdx > ctaIdx`) and rename the test to drop the now-irrelevant "so it can't spoil the result" framing &mdash; spoiler-safety lives in the data layer (day-before snapshot), not the visual order.

## Test plan

- [x] `npm test` &mdash; 100/100 passing.
- [ ] Manual: trigger the "Resend latest recap to me" admin button (once #150 lands) or send a test email; confirm in Gmail and Apple Mail that the strip renders directly under the CTA, above the footer divider.

https://claude.ai/code/session_01DqToXFzH1R6qegdNwFbMcY

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqToXFzH1R6qegdNwFbMcY)_