### PR TITLE
Fix zombie "running" cron rows: add fetch timeouts + sweeper + catch-up button (#154)

### DIFF
--- a/app/admin/actions.js
+++ b/app/admin/actions.js
@@ -57,6 +57,29 @@ export async function runMainCronAction(_prevState, _formData) {
   };
 }
 
+// Catch-up path (#154): bypasses the wake-window gate and forces a full
+// check + send. Use when an earlier tick was killed mid-run and missed
+// emails — `mlb_sent_notifications` dedupes, so already-sent users are skipped.
+export async function forceRunMainCronAction(_prevState, _formData) {
+  const auth = await assertAdmin();
+  if (!auth.ok) {
+    return { ok: false, message: auth.error, ranAt: new Date().toISOString() };
+  }
+
+  const supabase = createAdminClient();
+  const { status, body } = await runMainCron({
+    supabase,
+    emailsPaused: process.env.EMAILS_PAUSED === "true",
+    force: true,
+  });
+  return {
+    ok: status < 400,
+    message: body.message || body.error || "ran",
+    errors: body.errors,
+    ranAt: new Date().toISOString(),
+  };
+}
+
 export async function resendLatestRecapAction(_prevState, _formData) {
   const ranAt = new Date().toISOString();
   const auth = await assertAdmin();

--- a/app/admin/break-glass.js
+++ b/app/admin/break-glass.js
@@ -4,6 +4,7 @@ import { useActionState } from "react";
 import {
   runSchedulerAction,
   runMainCronAction,
+  forceRunMainCronAction,
   resendLatestRecapAction,
 } from "./actions";
 
@@ -25,6 +26,10 @@ export default function BreakGlass() {
         <BreakGlassButton
           label="Run main cron now"
           action={runMainCronAction}
+        />
+        <BreakGlassButton
+          label="Force run main cron (catch up missed)"
+          action={forceRunMainCronAction}
         />
         <BreakGlassButton
           label="Resend latest recap to me"

--- a/app/api/cron/route.test.js
+++ b/app/api/cron/route.test.js
@@ -60,7 +60,16 @@ function makeSupabaseMock({
       },
       update: (patch) => {
         updates.push(patch);
-        return { eq: async () => ({ error: null }) };
+        // Two callers: finalizeRun chains .eq(); sweepStuckRuns chains
+        // .in().lt().select() and returns rows swept.
+        return {
+          eq: async () => ({ error: null }),
+          in: () => ({
+            lt: () => ({
+              select: async () => ({ data: [], error: null }),
+            }),
+          }),
+        };
       },
     }),
     mlb_user_teams: () => ({
@@ -120,16 +129,17 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
     });
     expect(fetchSchedule).not.toHaveBeenCalled();
     // One heartbeat row: insert (status: running) + update (status: skipped_no_wake).
+    // Also expect a sweep update (#154) targeting status: "failure" via .in().
     expect(inserted).toEqual([{ status: "running" }]);
-    expect(updates).toHaveLength(1);
-    expect(updates[0]).toMatchObject({
+    const finalize = updates.find((u) => u.status === "skipped_no_wake");
+    expect(finalize).toMatchObject({
       status: "skipped_no_wake",
       games_processed: 0,
       emails_sent: 0,
       errors_count: 0,
       errors: null,
     });
-    expect(updates[0].finished_at).toEqual(expect.any(String));
+    expect(finalize.finished_at).toEqual(expect.any(String));
   });
 
   it("queries mlb_cron_schedule with an asymmetric window (now-2.5h, now+30m)", async () => {
@@ -161,7 +171,12 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
         if (table === "mlb_cron_runs") {
           return {
             insert: () => ({ select: () => ({ single: async () => ({ data: { id: "x" }, error: null }) }) }),
-            update: () => ({ eq: async () => ({ error: null }) }),
+            update: () => ({
+              eq: async () => ({ error: null }),
+              in: () => ({
+                lt: () => ({ select: async () => ({ data: [], error: null }) }),
+              }),
+            }),
           };
         }
         throw new Error(`unexpected ${table}`);
@@ -244,8 +259,8 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
     });
     expect(fetchSchedule).not.toHaveBeenCalled();
     expect(inserted).toEqual([{ status: "running" }]);
-    expect(updates).toHaveLength(1);
-    expect(updates[0]).toMatchObject({ status: "skipped_no_wake" });
+    // Updates may include a sweep entry (#154) in addition to the finalize.
+    expect(updates.find((u) => u.status === "skipped_no_wake")).toBeDefined();
 
     vi.useRealTimers();
   });
@@ -254,7 +269,12 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
     process.env.EMAILS_PAUSED = "true";
     const fromMock = vi.fn(() => ({
       insert: () => ({ select: () => ({ single: async () => ({ data: { id: "p" }, error: null }) }) }),
-      update: () => ({ eq: async () => ({ error: null }) }),
+      update: () => ({
+        eq: async () => ({ error: null }),
+        in: () => ({
+          lt: () => ({ select: async () => ({ data: [], error: null }) }),
+        }),
+      }),
     }));
     createAdminClient.mockReturnValue({ from: fromMock });
 

--- a/lib/brevo.js
+++ b/lib/brevo.js
@@ -1,5 +1,7 @@
 export const SENDER_NAME = "Ninth Inning Email";
 const BREVO_ENDPOINT = "https://api.brevo.com/v3/smtp/email";
+// Per-call timeout (#154) — see lib/mlb.js for rationale.
+const BREVO_FETCH_TIMEOUT_MS = 10000;
 
 export async function sendEmail(to, subject, html, { fetchImpl = fetch } = {}) {
   const res = await fetchImpl(BREVO_ENDPOINT, {
@@ -15,6 +17,7 @@ export async function sendEmail(to, subject, html, { fetchImpl = fetch } = {}) {
       subject,
       htmlContent: html,
     }),
+    signal: AbortSignal.timeout(BREVO_FETCH_TIMEOUT_MS),
   });
 
   if (!res.ok) {

--- a/lib/cron-jobs.js
+++ b/lib/cron-jobs.js
@@ -23,6 +23,36 @@ const LATE_BOUND_MS = 2.5 * 60 * 60 * 1000;
 
 const STALE_WAKE_HOURS = 36;
 
+// Defense-in-depth (#154): if a previous tick was killed by Cloudflare's
+// wall-clock before reaching finalizeRun(), its row stays at "running"
+// forever. Sweep anything older than this threshold to "failure" so the
+// admin dashboard reflects reality. Threshold is well past the worker's
+// HTTP wall-clock (~30s) but short enough that the next tick cleans up the
+// previous one before SLO B2 (30m silence) trips.
+const STALE_RUNNING_MS = 20 * 60 * 1000;
+
+async function sweepStuckRuns(supabase) {
+  const cutoff = new Date(Date.now() - STALE_RUNNING_MS).toISOString();
+  const { data, error } = await supabase
+    .from("mlb_cron_runs")
+    .update({
+      finished_at: new Date().toISOString(),
+      status: "failure",
+      errors: [
+        "Run did not reach finalizeRun — likely killed by Cloudflare wall-clock. Swept by sweepStuckRuns (#154).",
+      ],
+      errors_count: 1,
+    })
+    .in("status", ["running", "schedule_running"])
+    .lt("started_at", cutoff)
+    .select("id");
+  if (error) {
+    console.error("sweepStuckRuns failed:", error.message);
+    return 0;
+  }
+  return data?.length || 0;
+}
+
 function previousDateStr(dateStr) {
   const [y, m, d] = dateStr.split("-").map(Number);
   const dt = new Date(Date.UTC(y, m - 1, d));
@@ -81,49 +111,59 @@ async function finalizeRun(
 }
 
 // Runs the same logic as GET /api/cron — auth is the caller's responsibility.
+// `force: true` bypasses the wake-window gate and runs the full check
+// regardless. Used by the /admin "Force run main cron (catch up)" button to
+// resend emails that were missed while a previous tick was hung (#154).
 // Returns { status, body } where status is an HTTP status hint and body is the
 // JSON-able payload to render.
-export async function runMainCron({ supabase, emailsPaused = false } = {}) {
+export async function runMainCron({ supabase, emailsPaused = false, force = false } = {}) {
+  // Defense-in-depth: clean up any rows left "running" by a previous tick
+  // that was killed mid-execution (#154). Runs on every invocation so the
+  // dashboard stays accurate even in the no-wake path.
+  await sweepStuckRuns(supabase);
+
   if (emailsPaused) {
     const pausedRunId = await startRun(supabase, "running");
     await finalizeRun(supabase, pausedRunId, "paused");
     return { status: 200, body: { message: "Emails paused via kill switch" } };
   }
 
-  const now = Date.now();
-  const windowStart = new Date(now - LATE_BOUND_MS).toISOString();
-  const windowEnd = new Date(now + EARLY_BOUND_MS).toISOString();
-  const { data: activeWakes, error: scheduleError } = await supabase
-    .from("mlb_cron_schedule")
-    .select("game_pk")
-    .gte("expected_finish_at", windowStart)
-    .lte("expected_finish_at", windowEnd)
-    .limit(1);
-
-  if (scheduleError) {
-    console.error("mlb_cron_schedule read failed, falling through:", scheduleError.message);
-  } else if (!activeWakes || activeWakes.length === 0) {
-    const { data: anyRows, error: anyRowsError } = await supabase
+  if (!force) {
+    const now = Date.now();
+    const windowStart = new Date(now - LATE_BOUND_MS).toISOString();
+    const windowEnd = new Date(now + EARLY_BOUND_MS).toISOString();
+    const { data: activeWakes, error: scheduleError } = await supabase
       .from("mlb_cron_schedule")
       .select("game_pk")
+      .gte("expected_finish_at", windowStart)
+      .lte("expected_finish_at", windowEnd)
       .limit(1);
 
-    if (anyRowsError) {
-      console.error(
-        "mlb_cron_schedule emptiness check failed, falling through:",
-        anyRowsError.message
-      );
-    } else if ((!anyRows || anyRows.length === 0) && isInMlbSeason()) {
-      console.warn(
-        "mlb_cron_schedule is empty during MLB season — scheduler may be down, falling through to full check (#109)"
-      );
-    } else {
-      const heartbeatRunId = await startRun(supabase, "running");
-      await finalizeRun(supabase, heartbeatRunId, "skipped_no_wake");
-      return {
-        status: 200,
-        body: { message: "No scheduled wake within window — skipped" },
-      };
+    if (scheduleError) {
+      console.error("mlb_cron_schedule read failed, falling through:", scheduleError.message);
+    } else if (!activeWakes || activeWakes.length === 0) {
+      const { data: anyRows, error: anyRowsError } = await supabase
+        .from("mlb_cron_schedule")
+        .select("game_pk")
+        .limit(1);
+
+      if (anyRowsError) {
+        console.error(
+          "mlb_cron_schedule emptiness check failed, falling through:",
+          anyRowsError.message
+        );
+      } else if ((!anyRows || anyRows.length === 0) && isInMlbSeason()) {
+        console.warn(
+          "mlb_cron_schedule is empty during MLB season — scheduler may be down, falling through to full check (#109)"
+        );
+      } else {
+        const heartbeatRunId = await startRun(supabase, "running");
+        await finalizeRun(supabase, heartbeatRunId, "skipped_no_wake");
+        return {
+          status: 200,
+          body: { message: "No scheduled wake within window — skipped" },
+        };
+      }
     }
   }
 

--- a/lib/mlb.js
+++ b/lib/mlb.js
@@ -1,8 +1,14 @@
 // MLB Stats API utilities — shared between cron worker and any server context.
 
+// Per-call timeout so a slow upstream can't hang the cron's wall-clock budget
+// (issue #154). Cloudflare's `fetch()` waits indefinitely without an
+// AbortSignal; a single hung MLB request used to kill the whole tick before
+// `finalizeRun()` could update mlb_cron_runs, leaving rows zombied as "running".
+const MLB_FETCH_TIMEOUT_MS = 8000;
+
 export async function fetchSchedule(teamId, dateStr) {
   const url = `https://statsapi.mlb.com/api/v1/schedule?teamId=${teamId}&date=${dateStr}&sportId=1`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal: AbortSignal.timeout(MLB_FETCH_TIMEOUT_MS) });
   if (!res.ok) {
     throw new Error(`MLB API ${res.status} for team ${teamId} on ${dateStr}`);
   }
@@ -11,7 +17,7 @@ export async function fetchSchedule(teamId, dateStr) {
 
 export async function fetchDailySchedule(dateStr) {
   const url = `https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=${dateStr}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal: AbortSignal.timeout(MLB_FETCH_TIMEOUT_MS) });
   if (!res.ok) {
     throw new Error(`MLB API ${res.status} for daily schedule on ${dateStr}`);
   }
@@ -41,7 +47,7 @@ export function extractFinalGames(scheduleData) {
 
 export async function fetchGameContent(gamePk) {
   const url = `https://statsapi.mlb.com/api/v1/game/${gamePk}/content`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal: AbortSignal.timeout(MLB_FETCH_TIMEOUT_MS) });
   if (!res.ok) {
     throw new Error(`MLB content API ${res.status} for game ${gamePk}`);
   }
@@ -120,7 +126,7 @@ export async function fetchStandings(dateStr) {
   const apiDate = toMlbDateParam(dateStr);
   const season = dateStr.slice(0, 4);
   const url = `https://statsapi.mlb.com/api/v1/standings?leagueId=103,104&season=${season}&date=${apiDate}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { signal: AbortSignal.timeout(MLB_FETCH_TIMEOUT_MS) });
   if (!res.ok) {
     throw new Error(`MLB standings API ${res.status} for date ${dateStr}`);
   }

--- a/lib/mlb.test.js
+++ b/lib/mlb.test.js
@@ -35,7 +35,8 @@ describe("fetchSchedule", () => {
     const result = await fetchSchedule(147, "2026-04-27");
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://statsapi.mlb.com/api/v1/schedule?teamId=147&date=2026-04-27&sportId=1"
+      "https://statsapi.mlb.com/api/v1/schedule?teamId=147&date=2026-04-27&sportId=1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
     expect(result).toEqual(payload);
   });
@@ -100,7 +101,8 @@ describe("fetchGameContent", () => {
     const result = await fetchGameContent(746789);
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://statsapi.mlb.com/api/v1/game/746789/content"
+      "https://statsapi.mlb.com/api/v1/game/746789/content",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
     expect(result).toEqual(body);
   });
@@ -218,7 +220,8 @@ describe("fetchDailySchedule", () => {
     const result = await fetchDailySchedule("2026-05-02");
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=2026-05-02"
+      "https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=2026-05-02",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
     expect(result).toEqual(payload);
   });
@@ -299,7 +302,8 @@ describe("fetchStandings", () => {
     await fetchStandings("2024-07-04");
 
     expect(fetch).toHaveBeenCalledWith(
-      "https://statsapi.mlb.com/api/v1/standings?leagueId=103,104&season=2024&date=07/04/2024"
+      "https://statsapi.mlb.com/api/v1/standings?leagueId=103,104&season=2024&date=07/04/2024",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
   });
 


### PR DESCRIPTION
Closes #154.

## Summary

- `lib/mlb.js`, `lib/brevo.js`: every upstream `fetch()` now has an `AbortSignal.timeout()` (8s MLB, 10s Brevo). Without one, Cloudflare's `fetch()` waits indefinitely — a single slow MLB Stats API response was letting the worker run to its wall-clock limit and get killed before `finalizeRun()` could update `mlb_cron_runs`, leaving rows zombied as `running`. A hung upstream now throws a catchable error and the run finalizes as `failure`.
- `lib/cron-jobs.js`: `sweepStuckRuns()` runs at the top of `runMainCron` and marks any `running`/`schedule_running` row older than 20m as `failure`. Defense in depth so the admin dashboard reflects reality even if a future tick still gets killed mid-execution.
- `runMainCron({ force: true })` bypasses the wake-window gate, wired to a new **"Force run main cron (catch up missed)"** button on `/admin`. Use after an incident to flush emails that were missed while a previous tick was hung; `mlb_sent_notifications` dedupes so already-sent users are skipped.

## Root cause (from #154)

`/admin` showed every `running` row stuck with no `finished_at`, no duration, and `games_processed`/`emails_sent`/`errors_count` all 0 — meaning execution never reached `finalizeRun()`. The `try/catch` in `runMainCron` would have caught a thrown JS error and finalized as `failure`, so the row staying `running` means the worker was killed externally. The unbounded `fetch()` calls in `lib/mlb.js`/`lib/brevo.js` were the smoking gun: any one slow upstream blew the worker's HTTP wall-clock (~30s via `this.fetch()` in `scripts/inject-scheduled.mjs`).

## Test plan

- [x] `npm test` — 100 tests pass
- [ ] After deploy, click `/admin` → **Force run main cron (catch up missed)** to flush any emails missed during the incident
- [ ] Watch `mlb_cron_runs` over the next few `*/15` ticks — game-window runs should reach a terminal status (`success` / `no_new_highlights` / `partial`), not stay `running`
- [ ] Confirm next `skipped_no_wake` row still completes in ~125ms (sweep adds a tiny extra query but shouldn't materially slow it)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KArm3pPV1qzVxzuc3kxNnp)_