### PR TITLE
Run scheduled() cron via direct calls, not this.fetch (#157)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,12 +193,14 @@ Three pieces, two of them dashboard-only:
 
 ## Cron architecture
 
-Two Cloudflare cron triggers wired in `wrangler.jsonc`, routed to different endpoints by `event.cron` in `scripts/inject-scheduled.mjs` (closes #76):
+Two Cloudflare cron triggers wired in `wrangler.jsonc`, dispatched by `event.cron` in the `scheduled()` handler injected by `scripts/inject-scheduled.mjs` (closes #76, #157):
 
-| Cron | Endpoint | Purpose |
-|------|----------|---------|
-| `0 13 * * *` (daily, 9am ET in EDT) | `/api/cron/schedule` | Pulls today's MLB slate via `fetchDailySchedule`, upserts one row per game into `mlb_cron_schedule` with `expected_finish_at = first_pitch + 3.5h`, prunes rows older than 36h |
-| `*/15 * * * *` (every 15 min) | `/api/cron` | Reads `mlb_cron_schedule`; if no row's `expected_finish_at` is inside the polling window it returns early (no MLB API hits) but still writes a `skipped_no_wake` heartbeat row to `mlb_cron_runs` (#104). Exception (#109): if the table is **entirely empty** during MLB regular season (ET month ∈ [4..10]) the main cron falls through to the full check rather than early-returning, so a dead daily scheduler can't drop a day of emails. Otherwise runs the full check + send fan-out |
+| Cron | Job | Purpose |
+|------|-----|---------|
+| `0 13 * * *` (daily, 9am ET in EDT) | `runScheduler` | Pulls today's MLB slate via `fetchDailySchedule`, upserts one row per game into `mlb_cron_schedule` with `expected_finish_at = first_pitch + 3.5h`, prunes rows older than 36h |
+| `*/15 * * * *` (every 15 min) | `runMainCron` | Reads `mlb_cron_schedule`; if no row's `expected_finish_at` is inside the polling window it returns early (no MLB API hits) but still writes a `skipped_no_wake` heartbeat row to `mlb_cron_runs` (#104). Exception (#109): if the table is **entirely empty** during MLB regular season (ET month ∈ [4..10]) the main cron falls through to the full check rather than early-returning, so a dead daily scheduler can't drop a day of emails. Otherwise runs the full check + send fan-out |
+
+The scheduled handler calls `runMainCron` / `runScheduler` (from `lib/cron-jobs.js`) directly via `ctx.waitUntil()` rather than round-tripping through `this.fetch('/api/cron')`. The HTTP round-trip inherited the ~30s request wall-clock; calling the functions directly gives the work the 15-min scheduled-event budget instead. The `/api/cron` and `/api/cron/schedule` HTTP routes are unchanged and still backstop `/admin` break-glass + any human curl recovery — they just no longer share the path with the cron trigger (#157). The build-time shim that exposes these functions to the injected handler lives at `scripts/cron-shim.mjs`.
 
 The polling window is asymmetric: `expected_finish_at` between `now - 2.5h` and `now + 30m`. Starting 30 min before the predicted finish catches short games; continuing 2.5h after catches extra innings and rain delays. Constants live at the top of `app/api/cron/route.js` (`EARLY_BOUND_MS`, `LATE_BOUND_MS`).
 

--- a/scripts/cron-shim.mjs
+++ b/scripts/cron-shim.mjs
@@ -1,0 +1,13 @@
+// Build-time shim that exposes the cron entry points on globalThis so the
+// injected scheduled() handler can call them directly instead of going
+// through this.fetch() (#157). Bundled by scripts/inject-scheduled.mjs and
+// prepended to .open-next/worker.js — not loaded by Next.js at runtime.
+
+import { runMainCron, runScheduler } from "@/lib/cron-jobs";
+import { createAdminClient } from "@/lib/supabase-admin";
+
+globalThis.__ninthInningCron = {
+  runMainCron,
+  runScheduler,
+  createAdminClient,
+};

--- a/scripts/inject-scheduled.mjs
+++ b/scripts/inject-scheduled.mjs
@@ -1,40 +1,105 @@
-// Injects the scheduled() handler into the OpenNext-generated worker.js
-// Run after `opennextjs-cloudflare build` and before deploy.
+// Injects the scheduled() handler into the OpenNext-generated worker.js.
+// Run after `opennextjs-cloudflare build` and before deploy (wired via
+// wrangler.jsonc's build.command and the `npm run deploy` script).
+//
+// Why this isn't a one-liner: the scheduled handler needs to call our cron
+// entry points (runMainCron / runScheduler from lib/cron-jobs.js) without
+// round-tripping through this.fetch(). That HTTP self-call was the previous
+// approach but it inherits the ~30s HTTP request wall-clock instead of the
+// 15-min scheduled-event budget — a tighter envelope than the work needs
+// (see postmortem #154 and the follow-up in #157).
+//
+// Two pieces are injected:
+//   1. A "cron shim" (scripts/cron-shim.mjs) bundled with esbuild and
+//      prepended to worker.js. It registers runMainCron, runScheduler, and
+//      createAdminClient on globalThis.__ninthInningCron at worker startup,
+//      bringing those symbols out of the (bundled, internal) module graph.
+//   2. A scheduled() method on the worker's default export. It reads the
+//      shim's functions from globalThis, bridges Worker secrets into
+//      process.env (mirroring OpenNext's populateProcessEnv — see
+//      node_modules/@opennextjs/cloudflare/dist/cli/templates/init.js — which
+//      the fetch wrapper does for us but the scheduled handler bypasses), and
+//      hands the long-running work to ctx.waitUntil() so it gets the 15-min
+//      scheduled-event budget.
+//
+// The /api/cron and /api/cron/schedule HTTP routes are unchanged: the
+// /admin break-glass buttons (#110) and any human curl-based recovery still
+// go through them. We just no longer share that path with the cron trigger.
 
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import esbuild from "esbuild";
 
-const workerPath = ".open-next/worker.js";
+// OPEN_NEXT_WORKER_PATH lets the test harness point at a synthetic worker
+// in a tempdir; the deploy pipeline always uses the default.
+const workerPath = process.env.OPEN_NEXT_WORKER_PATH || ".open-next/worker.js";
 const worker = readFileSync(workerPath, "utf-8");
 
-if (worker.includes("scheduled")) {
-  console.log("scheduled handler already present, skipping injection.");
+const INJECTION_MARKER = "__ninthInningCron";
+
+if (worker.includes(INJECTION_MARKER)) {
+  console.log("Cron shim already present, skipping injection.");
   process.exit(0);
 }
 
-// Call the worker's own fetch handler directly instead of making an external
-// HTTP request, which hits Cloudflare error 1042 (self-referencing route).
-//
+// Bundle the shim so cron-jobs and its deps (including @supabase/supabase-js)
+// end up as plain JS reachable from the worker's top-level scope. IIFE format
+// wraps everything in a self-scoped function so minified identifiers can't
+// collide with worker.js's own minified bindings when the two are concatenated.
+const result = await esbuild.build({
+  entryPoints: ["scripts/cron-shim.mjs"],
+  bundle: true,
+  format: "iife",
+  platform: "neutral",
+  conditions: ["workerd", "worker", "browser"],
+  mainFields: ["browser", "module", "main"],
+  target: "es2022",
+  write: false,
+  alias: { "@": resolve(".") },
+  legalComments: "none",
+  logLevel: "warning",
+  minify: true,
+});
+
+const shimCode = result.outputFiles[0].text;
+
 // Two cron triggers are wired in wrangler.jsonc (#76):
-//   - "*/15 * * * *" → /api/cron (main worker, early-returns when no wake)
-//   - "0 13 * * *"   → /api/cron/schedule (daily 9am ET scheduler)
-// Routing is by event.cron string. Anything we don't recognise falls through
-// to /api/cron so a misconfigured trigger doesn't silently drop the run.
+//   - "*/15 * * * *" → runMainCron
+//   - "0 13 * * *"   → runScheduler
+// Anything we don't recognise falls through to runMainCron so a misconfigured
+// trigger doesn't silently drop the run.
 const scheduledHandler = `
     async scheduled(event, env, ctx) {
-        const path = event.cron === "0 13 * * *" ? "/api/cron/schedule" : "/api/cron";
-        try {
-            const request = new Request(\`https://dummy\${path}\`, {
-                headers: { Authorization: \`Bearer \${env.CRON_SECRET}\` },
-            });
-            const response = await this.fetch(request, env, ctx);
-            const body = await response.text();
-            console.log(\`Cron \${path} response (\${response.status}): \${body}\`);
-        } catch (err) {
-            console.error(\`Cron handler error (\${path}): \${err.message}\`);
+        const cron = globalThis.__ninthInningCron;
+        if (!cron) {
+            console.error("scheduled() invoked before cron shim loaded — bundle is broken");
+            return;
         }
+        // Mirror OpenNext's populateProcessEnv: the fetch wrapper bridges Worker
+        // secrets into process.env on the first request, but scheduled() bypasses
+        // that wrapper entirely. lib/cron-jobs.js → lib/brevo.js / supabase-admin
+        // read process.env directly, so populate it before invoking either job.
+        for (const [k, v] of Object.entries(env)) {
+            if (typeof v === "string") process.env[k] = v;
+        }
+        const job = event.cron === "0 13 * * *" ? "schedule" : "main";
+        const work = (async () => {
+            try {
+                const supabase = cron.createAdminClient();
+                const result = job === "schedule"
+                    ? await cron.runScheduler({ supabase })
+                    : await cron.runMainCron({
+                        supabase,
+                        emailsPaused: env.EMAILS_PAUSED === "true",
+                    });
+                console.log(\`Cron \${job} status \${result.status}\`);
+            } catch (err) {
+                console.error(\`Cron \${job} handler error:\`, err && (err.stack || err.message) || err);
+            }
+        })();
+        ctx.waitUntil(work);
     },`;
 
-// Insert scheduled() right before the fetch() method
 const patched = worker.replace(
   /async fetch\(request, env, ctx\) \{/,
   `${scheduledHandler}\n    async fetch(request, env, ctx) {`
@@ -45,5 +110,8 @@ if (patched === worker) {
   process.exit(1);
 }
 
-writeFileSync(workerPath, patched);
-console.log("Injected scheduled() handler into worker.js");
+// Prepend the bundled shim so globalThis.__ninthInningCron is populated at
+// worker startup, before any scheduled() invocation can reach for it. ESM
+// imports hoist, so prepending text doesn't reorder the worker's own imports.
+writeFileSync(workerPath, `${shimCode}\n${patched}`);
+console.log("Injected cron shim + scheduled() handler into worker.js");

--- a/scripts/inject-scheduled.test.mjs
+++ b/scripts/inject-scheduled.test.mjs
@@ -1,0 +1,114 @@
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Drives scripts/inject-scheduled.mjs against a synthetic worker.js and
+// asserts the patched output has the right shape. Exists because the
+// 2026-05-17 incident (#154) traced back to scheduled() using the HTTP
+// wall-clock instead of the scheduled-event budget — the inject script is
+// the only thing that wires up scheduled(), so a regression here is a
+// silent recipe for the same problem (#157).
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const injectScript = join(repoRoot, "scripts/inject-scheduled.mjs");
+
+let workDir;
+let workerPath;
+
+const SYNTHETIC_WORKER = `// synthetic OpenNext output for tests
+export default {
+    async fetch(request, env, ctx) {
+        return new Response("hello");
+    },
+};
+`;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "inject-scheduled-"));
+  workerPath = join(workDir, "worker.js");
+  writeFileSync(workerPath, SYNTHETIC_WORKER);
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+function runInject() {
+  return execFileSync("node", [injectScript], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      // Point the script at our temp worker.js by symlinking via a relative
+      // override. The script reads ".open-next/worker.js" relative to cwd —
+      // we expose the temp file at that path via the env var below, which
+      // the test-only branch in the script honors.
+      OPEN_NEXT_WORKER_PATH: workerPath,
+    },
+  });
+}
+
+describe("inject-scheduled", () => {
+  it("injects a scheduled() handler that does NOT call this.fetch", () => {
+    runInject();
+    const patched = readFileSync(workerPath, "utf-8");
+
+    expect(patched).toContain("async scheduled(event, env, ctx)");
+    // The whole point of #157: stop doing internal HTTP. If a future edit
+    // brings this.fetch() back inside scheduled(), this test fails loudly.
+    // Slice from `async scheduled` to the next `async fetch` after it (the
+    // bundled IIFE shim has its own async fetch methods earlier in the file).
+    const scheduledIdx = patched.indexOf("async scheduled");
+    const scheduledBlock = patched.slice(
+      scheduledIdx,
+      patched.indexOf("async fetch", scheduledIdx)
+    );
+    expect(scheduledBlock).not.toContain("this.fetch");
+    expect(scheduledBlock).not.toContain("new Request");
+  });
+
+  it("wires scheduled() to ctx.waitUntil so it gets the 15-min cron budget", () => {
+    runInject();
+    const patched = readFileSync(workerPath, "utf-8");
+    expect(patched).toContain("ctx.waitUntil");
+  });
+
+  it("routes the 9am ET cron to runScheduler and others to runMainCron", () => {
+    runInject();
+    const patched = readFileSync(workerPath, "utf-8");
+    expect(patched).toContain('"0 13 * * *"');
+    expect(patched).toContain("runScheduler");
+    expect(patched).toContain("runMainCron");
+  });
+
+  it("prepends the cron shim that registers __ninthInningCron on globalThis", () => {
+    runInject();
+    const patched = readFileSync(workerPath, "utf-8");
+    expect(patched).toContain("__ninthInningCron");
+    // Shim must register __ninthInningCron *before* the injected scheduled()
+    // handler, so the handler can find the symbols on first invocation.
+    // (We can't anchor on "async fetch" because the bundled supabase client
+    //  contains async fetch methods of its own.)
+    expect(patched.indexOf("__ninthInningCron")).toBeLessThan(
+      patched.indexOf("async scheduled")
+    );
+  });
+
+  it("bridges Worker env into process.env (OpenNext fetch wrapper does this, scheduled bypasses it)", () => {
+    runInject();
+    const patched = readFileSync(workerPath, "utf-8");
+    expect(patched).toContain("process.env");
+    expect(patched).toContain("Object.entries(env)");
+  });
+
+  it("is idempotent — running it twice does not double-inject", () => {
+    runInject();
+    const once = readFileSync(workerPath, "utf-8");
+    runInject();
+    const twice = readFileSync(workerPath, "utf-8");
+    expect(twice).toBe(once);
+  });
+});


### PR DESCRIPTION
Closes #157.

## Summary

- The injected `scheduled()` handler used to call `this.fetch()` to invoke `/api/cron` or `/api/cron/schedule`. That inherits the ~30s HTTP request wall-clock instead of the 15-min scheduled-event budget — the tight envelope that turned a slow MLB API call into a killed worker in #154.
- New build-time shim (`scripts/cron-shim.mjs`) is esbuild-bundled (IIFE, minified, ~205KB) and prepended to `.open-next/worker.js`. It registers `runMainCron` / `runScheduler` / `createAdminClient` on `globalThis.__ninthInningCron` at worker startup.
- The injected `scheduled()` handler now: bridges `env` → `process.env` (mirroring OpenNext's `populateProcessEnv`, which the fetch wrapper does but `scheduled()` bypasses), dispatches by `event.cron` directly to the right job, and hands the work to `ctx.waitUntil()` so it gets the cron budget. No `this.fetch`, no `new Request`.
- `/api/cron` and `/api/cron/schedule` HTTP routes are unchanged — `/admin` break-glass (#110) and any human curl recovery still go through them. The cron trigger just no longer shares that path.

## Success conditions from #157

- [x] `scheduled()` no longer calls `this.fetch(...)` for its own routes
- [x] `mlb_cron_runs` keeps writing rows on every tick (runMainCron/runScheduler call startRun/finalizeRun unchanged)
- [x] `/admin` break-glass buttons still work (go through `app/admin/actions.js` → `lib/cron-jobs.js` directly)
- [x] Updated `scripts/inject-scheduled.mjs` comment block to reflect the new wiring
- [ ] A `wrangler tail` during a real `*/15` tick shows the cron's logs but no internal HTTP request log entry for `/api/cron` — needs a real deploy to verify

## Test plan

- [x] `npm test` passes (106 tests, +6 new)
- [x] New `scripts/inject-scheduled.test.mjs` drives the inject script against a synthetic worker.js and asserts:
  - no `this.fetch` / `new Request` in the injected scheduled block
  - uses `ctx.waitUntil`
  - routes `0 13 * * *` to `runScheduler`, others to `runMainCron`
  - shim registers `__ninthInningCron` before `async scheduled`
  - bridges `Object.entries(env)` into `process.env`
  - idempotent on second run
- [ ] After merge + deploy, watch `wrangler tail` during a `*/15` tick to confirm no `/api/cron` subrequest log entry
- [ ] Confirm `mlb_cron_runs` keeps writing the expected `skipped_no_wake` heartbeat + game-window rows
- [ ] Click each `/admin` break-glass button to confirm the HTTP routes still respond


---
_Generated by [Claude Code](https://claude.ai/code/session_011gT5DEDrFAftr6u7NQknGa)_