### PR TITLE
Bound fetch() in post-deploy-check (#159)

### DIFF
--- a/scripts/post-deploy-check.mjs
+++ b/scripts/post-deploy-check.mjs
@@ -20,6 +20,14 @@ const CF_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
 const WORKER_NAME = "mlb";
 const EXPECTED_CRONS = ["*/15 * * * *", "0 13 * * *"];
 
+// Per-call timeouts (#159). Unbounded fetch() lets a hung endpoint wedge the
+// deploy script indefinitely. The bootstrap call wraps a Worker request that
+// itself hits MLB + Supabase, so its budget is wider than the Cloudflare/MLB
+// probes that follow.
+const BOOTSTRAP_TIMEOUT_MS = 30000;
+const CF_API_TIMEOUT_MS = 10000;
+const MLB_API_TIMEOUT_MS = 8000;
+
 function fail(msg) {
   console.error(`\npost-deploy: FAIL — ${msg}`);
   process.exit(1);
@@ -51,6 +59,7 @@ let bootstrapResp;
 try {
   bootstrapResp = await fetch(`${SITE_URL}/api/cron/schedule`, {
     headers: { Authorization: `Bearer ${CRON_SECRET}` },
+    signal: AbortSignal.timeout(BOOTSTRAP_TIMEOUT_MS),
   });
 } catch (err) {
   fail(`network error calling /api/cron/schedule: ${err.message}`);
@@ -84,7 +93,10 @@ if (CF_API_TOKEN && CF_ACCOUNT_ID) {
   const url = `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/workers/scripts/${WORKER_NAME}/schedules`;
   let cfResp;
   try {
-    cfResp = await fetch(url, { headers: { Authorization: `Bearer ${CF_API_TOKEN}` } });
+    cfResp = await fetch(url, {
+      headers: { Authorization: `Bearer ${CF_API_TOKEN}` },
+      signal: AbortSignal.timeout(CF_API_TIMEOUT_MS),
+    });
   } catch (err) {
     fail(`network error calling Cloudflare schedules API: ${err.message}`);
   }
@@ -120,7 +132,10 @@ if (wakeCount > 0) {
   // hide behind a "must be offseason" assumption.
   let mlbHasGames = null;
   try {
-    const mlbResp = await fetch(`https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=${dateStr}`);
+    const mlbResp = await fetch(
+      `https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=${dateStr}`,
+      { signal: AbortSignal.timeout(MLB_API_TIMEOUT_MS) },
+    );
     if (mlbResp.ok) {
       const data = await mlbResp.json();
       mlbHasGames = (data?.dates?.[0]?.games || []).length > 0;


### PR DESCRIPTION
Closes #159.

## Audit results

Swept `lib/`, `app/api/`, and `scripts/` for unbounded external I/O per #156's
"every piece of external I/O is bounded by time" policy.

| Location | Status |
|---|---|
| `lib/mlb.js` (4 fetches) | **(a) bounded** — `AbortSignal.timeout(8000)` after #155 |
| `lib/brevo.js` (1 fetch) | **(a) bounded** — `AbortSignal.timeout(10000)` after #155 |
| `lib/cron-jobs.js`, `lib/resend-recap.js`, `lib/welcome-email.js` | **(a) bounded** — delegate to the helpers above |
| `app/api/*/route.js`, `app/auth/callback/route.js` | **(a) bounded** — no direct `fetch()`, only Supabase clients (which have their own internal timeouts) |
| `app/login/page.js`, `app/dashboard/team-grid.js`, `app/unsubscribe/page.js` | n/a — browser-side fetch, not Worker code |
| Loops (`while(true)`, `setInterval`, `for...of await`) | none found. `runMainCron`'s teams×dates loop is bounded by subscriber count (≤30 teams × 3 dates × ~5 users today — revisit at 10k users per #159) |
| **`scripts/post-deploy-check.mjs` (3 fetches)** | **(b) fixed in this PR** |

## Fix

`scripts/post-deploy-check.mjs` runs locally during `npm run deploy`. Not a
Cloudflare Worker, but per #156 still in scope — an unbounded fetch here lets a
hung endpoint wedge the deploy script indefinitely. Three call sites needed
timeouts:

- bootstrap `POST /api/cron/schedule` — 30s (wraps a Worker request that itself
  hits MLB + Supabase, so its budget is wider than the probes below)
- Cloudflare schedules API — 10s
- MLB API offseason probe — 8s (matches `MLB_FETCH_TIMEOUT_MS` in `lib/mlb.js`)

## Skipped

The optional ESLint rule / unit test banning `fetch(` without `signal:` —
issue called it "only worth it if the audit finds non-trivial hits." Audit
found 3 hits in one script, all on the deploy hot path rather than the
Worker hot path, so I skipped it. Trivial to add later if regressions show up.

## Test plan

- [x] `npm test` — 106/106 passing
- [ ] Next `npm run deploy` exercises all three fixed fetches; failure mode is
      "deploy exits non-zero with a TimeoutError" instead of "hangs forever"


---
_Generated by [Claude Code](https://claude.ai/code/session_01ACiiyCreKEcurAL2fGf6kd)_