### PR TITLE
Pass env directly to bundled cron functions (#163)

### DIFF
--- a/lib/brevo.js
+++ b/lib/brevo.js
@@ -3,16 +3,21 @@ const BREVO_ENDPOINT = "https://api.brevo.com/v3/smtp/email";
 // Per-call timeout (#154) — see lib/mlb.js for rationale.
 const BREVO_FETCH_TIMEOUT_MS = 10000;
 
-export async function sendEmail(to, subject, html, { fetchImpl = fetch } = {}) {
+export async function sendEmail(
+  to,
+  subject,
+  html,
+  { fetchImpl = fetch, apiKey, fromEmail } = {}
+) {
   const res = await fetchImpl(BREVO_ENDPOINT, {
     method: "POST",
     headers: {
-      "api-key": process.env.EMAIL_API_KEY,
+      "api-key": apiKey ?? process.env.EMAIL_API_KEY,
       "Content-Type": "application/json",
       Accept: "application/json",
     },
     body: JSON.stringify({
-      sender: { email: process.env.FROM_EMAIL, name: SENDER_NAME },
+      sender: { email: fromEmail ?? process.env.FROM_EMAIL, name: SENDER_NAME },
       to: [{ email: to }],
       subject,
       htmlContent: html,

--- a/lib/brevo.test.js
+++ b/lib/brevo.test.js
@@ -62,6 +62,25 @@ describe("sendEmail", () => {
     expect(body.htmlContent).toBe("<p>watch</p>");
   });
 
+  it("accepts explicit apiKey/fromEmail args (Worker scheduled path, #163)", async () => {
+    // The scheduled handler can't rely on process.env reaching the bundled
+    // sendEmail — it threads env values explicitly. Override process.env to
+    // junk to prove the explicit args win and process.env isn't read.
+    process.env.EMAIL_API_KEY = "process-env-key-should-not-be-used";
+    process.env.FROM_EMAIL = "wrong@example.com";
+
+    const fetchImpl = makeFetchStub();
+    await sendEmail("user@example.com", "subject", "<p>body</p>", {
+      fetchImpl,
+      apiKey: "worker-binding-key",
+      fromEmail: "binding@ninthinning.email",
+    });
+
+    const [, init] = fetchImpl.mock.calls[0];
+    expect(init.headers["api-key"]).toBe("worker-binding-key");
+    expect(JSON.parse(init.body).sender.email).toBe("binding@ninthinning.email");
+  });
+
   it("throws with the Brevo status and body excerpt on non-2xx", async () => {
     const fetchImpl = makeFetchStub({
       ok: false,

--- a/lib/cron-jobs.js
+++ b/lib/cron-jobs.js
@@ -114,9 +114,20 @@ async function finalizeRun(
 // `force: true` bypasses the wake-window gate and runs the full check
 // regardless. Used by the /admin "Force run main cron (catch up)" button to
 // resend emails that were missed while a previous tick was hung (#154).
+// `env` is the Cloudflare Worker bindings, passed in only by the scheduled
+// handler — its process.env bridge doesn't reach the bundled libs, so it has
+// to thread Worker-side values explicitly (#163). HTTP callers omit it and
+// the libs fall back to process.env (which OpenNext's fetch wrapper has
+// populated by then).
 // Returns { status, body } where status is an HTTP status hint and body is the
 // JSON-able payload to render.
-export async function runMainCron({ supabase, emailsPaused = false, force = false } = {}) {
+export async function runMainCron({ supabase, env, emailsPaused = false, force = false } = {}) {
+  const emailOpts = env
+    ? { apiKey: env.EMAIL_API_KEY, fromEmail: env.FROM_EMAIL }
+    : undefined;
+  const templateOpts = env
+    ? { siteUrl: env.SITE_URL, tipUrl: env.TIP_URL }
+    : undefined;
   // Defense-in-depth: clean up any rows left "running" by a previous tick
   // that was killed mid-execution (#154). Runs on every invocation so the
   // dashboard stays accurate even in the no-wake path.
@@ -327,10 +338,17 @@ export async function runMainCron({ supabase, emailsPaused = false, force = fals
         const subject = `${teamName} Highlights — ${formatDisplayDate(game.gameDate)}`;
         const standings = standingsByDate.get(game.gameDate);
         const standing = standings ? extractTeamStanding(standings, game.teamId) : null;
-        const html = buildEmailHtml(team, game.highlightUrl, userId, game.gameDate, standing);
+        const html = buildEmailHtml(
+          team,
+          game.highlightUrl,
+          userId,
+          game.gameDate,
+          standing,
+          templateOpts
+        );
 
         try {
-          await sendEmail(email, subject, html);
+          await sendEmail(email, subject, html, emailOpts);
 
           await supabase.from("mlb_sent_notifications").insert({
             user_id: userId,

--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -13,19 +13,20 @@ function brandWordmarkHtml({ size = 16, ink = "#1a1d1c", periodColor = BRAND_GRE
   return `<span style="font-family:'General Sans','Hanken Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-weight:500;font-size:${size}px;letter-spacing:-0.015em;color:${ink};white-space:nowrap;">ninthinning<span style="color:${periodColor};margin:0 1px;">&#9670;</span>email</span>`;
 }
 
-function getSiteUrl() {
+function getSiteUrl(override) {
   return (
+    override ||
     process.env.SITE_URL ||
     process.env.NEXT_PUBLIC_SITE_URL ||
     "https://yourdomain.com"
   );
 }
 
-export function buildWelcomeEmailHtml(userId) {
-  const siteUrl = getSiteUrl();
+export function buildWelcomeEmailHtml(userId, { siteUrl: siteUrlOverride, tipUrl: tipUrlOverride } = {}) {
+  const siteUrl = getSiteUrl(siteUrlOverride);
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
   const dashboardUrl = `${siteUrl}/dashboard`;
-  const tipUrl = process.env.TIP_URL;
+  const tipUrl = tipUrlOverride ?? process.env.TIP_URL;
   const accent = BRAND_GREEN;
 
   return `<!DOCTYPE html>
@@ -177,10 +178,17 @@ function ordinal(n) {
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }
 
-export function buildEmailHtml(team, highlightUrl, userId, gameDate, standing = null) {
-  const siteUrl = getSiteUrl();
+export function buildEmailHtml(
+  team,
+  highlightUrl,
+  userId,
+  gameDate,
+  standing = null,
+  { siteUrl: siteUrlOverride, tipUrl: tipUrlOverride } = {}
+) {
+  const siteUrl = getSiteUrl(siteUrlOverride);
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
-  const tipUrl = process.env.TIP_URL;
+  const tipUrl = tipUrlOverride ?? process.env.TIP_URL;
   const teamName = team?.name || "Your team";
   const teamColor = team?.color || "#2563eb";
   const teamAbbr = team?.abbr || "";

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -53,6 +53,26 @@ describe("buildEmailHtml", () => {
     );
   });
 
+  it("accepts explicit siteUrl/tipUrl overrides (Worker scheduled path, #163)", () => {
+    // The cron's scheduled handler can't rely on process.env reaching this
+    // bundled module — it threads env values explicitly. Junk process.env to
+    // prove overrides win.
+    process.env.SITE_URL = "https://wrong.example.com";
+    process.env.TIP_URL = "https://wrong-tip.example.com";
+    const html = buildEmailHtml(
+      TEAM,
+      HIGHLIGHT_URL,
+      USER_ID,
+      GAME_DATE,
+      null,
+      { siteUrl: "https://ninthinning.email", tipUrl: "https://buy.stripe.com/x" }
+    );
+    expect(html).toContain(`https://ninthinning.email/unsubscribe?token=${USER_ID}`);
+    expect(html).toContain("https://buy.stripe.com/x");
+    expect(html).not.toContain("wrong.example.com");
+    expect(html).not.toContain("wrong-tip.example.com");
+  });
+
   it("includes the tip prompt when TIP_URL is set", () => {
     process.env.TIP_URL = "https://buymeacoffee.com/example";
     const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE);

--- a/lib/supabase-admin.js
+++ b/lib/supabase-admin.js
@@ -2,9 +2,14 @@ import { createClient } from "@supabase/supabase-js";
 
 // Service-role client for server-side operations (cron worker, etc.)
 // This bypasses Row Level Security — use only in trusted server contexts.
-export function createAdminClient() {
+//
+// Accepts explicit url/key args so the Cloudflare scheduled() handler can pass
+// Worker bindings directly (its process.env bridge doesn't reach this bundled
+// module — see #163). HTTP callers leave the args undefined and pick up
+// process.env via OpenNext's fetch wrapper, which is the path that works.
+export function createAdminClient(supabaseUrl, serviceRoleKey) {
   return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.SUPABASE_SERVICE_ROLE_KEY
+    supabaseUrl ?? process.env.NEXT_PUBLIC_SUPABASE_URL,
+    serviceRoleKey ?? process.env.SUPABASE_SERVICE_ROLE_KEY
   );
 }

--- a/scripts/inject-scheduled.mjs
+++ b/scripts/inject-scheduled.mjs
@@ -15,12 +15,11 @@
 //      createAdminClient on globalThis.__ninthInningCron at worker startup,
 //      bringing those symbols out of the (bundled, internal) module graph.
 //   2. A scheduled() method on the worker's default export. It reads the
-//      shim's functions from globalThis, bridges Worker secrets into
-//      process.env (mirroring OpenNext's populateProcessEnv — see
-//      node_modules/@opennextjs/cloudflare/dist/cli/templates/init.js — which
-//      the fetch wrapper does for us but the scheduled handler bypasses), and
-//      hands the long-running work to ctx.waitUntil() so it gets the 15-min
-//      scheduled-event budget.
+//      shim's functions from globalThis, passes the Worker env bindings
+//      directly to those functions (an earlier version mirrored OpenNext's
+//      populateProcessEnv and wrote to process.env, but that didn't reach the
+//      bundled module graph in workerd — see #163), and hands the long-running
+//      work to ctx.waitUntil() so it gets the 15-min scheduled-event budget.
 //
 // The /api/cron and /api/cron/schedule HTTP routes are unchanged: the
 // /admin break-glass buttons (#110) and any human curl-based recovery still
@@ -75,21 +74,25 @@ const scheduledHandler = `
             console.error("scheduled() invoked before cron shim loaded — bundle is broken");
             return;
         }
-        // Mirror OpenNext's populateProcessEnv: the fetch wrapper bridges Worker
-        // secrets into process.env on the first request, but scheduled() bypasses
-        // that wrapper entirely. lib/cron-jobs.js → lib/brevo.js / supabase-admin
-        // read process.env directly, so populate it before invoking either job.
-        for (const [k, v] of Object.entries(env)) {
-            if (typeof v === "string") process.env[k] = v;
-        }
+        // Pass env explicitly to the bundled cron functions. An earlier version
+        // tried to bridge env into process.env so the libs' process.env reads
+        // would work transparently — that's what OpenNext's fetch wrapper does
+        // for HTTP requests. But the bundled IIFE shim resolves process.env
+        // through its own module graph and doesn't see writes made from this
+        // injected handler (#163). Threading env to each lib is uglier but it
+        // actually works.
         const job = event.cron === "0 13 * * *" ? "schedule" : "main";
         const work = (async () => {
             try {
-                const supabase = cron.createAdminClient();
+                const supabase = cron.createAdminClient(
+                    env.NEXT_PUBLIC_SUPABASE_URL,
+                    env.SUPABASE_SERVICE_ROLE_KEY
+                );
                 const result = job === "schedule"
                     ? await cron.runScheduler({ supabase })
                     : await cron.runMainCron({
                         supabase,
+                        env,
                         emailsPaused: env.EMAILS_PAUSED === "true",
                     });
                 console.log(\`Cron \${job} status \${result.status}\`);

--- a/scripts/inject-scheduled.test.mjs
+++ b/scripts/inject-scheduled.test.mjs
@@ -97,11 +97,25 @@ describe("inject-scheduled", () => {
     );
   });
 
-  it("bridges Worker env into process.env (OpenNext fetch wrapper does this, scheduled bypasses it)", () => {
+  it("passes env directly to the bundled cron functions instead of bridging process.env (#163)", () => {
     runInject();
     const patched = readFileSync(workerPath, "utf-8");
-    expect(patched).toContain("process.env");
-    expect(patched).toContain("Object.entries(env)");
+    const scheduledIdx = patched.indexOf("async scheduled");
+    const scheduledBlock = patched.slice(
+      scheduledIdx,
+      patched.indexOf("async fetch", scheduledIdx)
+    );
+    // The supabase URL/key come straight off env, not process.env. The earlier
+    // process.env bridge silently failed in workerd because the bundled IIFE
+    // shim doesn't see writes made from this injected handler — #163.
+    expect(scheduledBlock).toContain("env.NEXT_PUBLIC_SUPABASE_URL");
+    expect(scheduledBlock).toContain("env.SUPABASE_SERVICE_ROLE_KEY");
+    // runMainCron receives env so it can thread EMAIL_API_KEY / FROM_EMAIL /
+    // SITE_URL / TIP_URL to brevo + email-template.
+    expect(scheduledBlock).toMatch(/runMainCron\(\{[^}]*env[^}]*\}\)/s);
+    // The doomed process.env bridge must stay gone.
+    expect(scheduledBlock).not.toContain("process.env[");
+    expect(scheduledBlock).not.toContain("Object.entries(env)");
   });
 
   it("is idempotent — running it twice does not double-inject", () => {


### PR DESCRIPTION
## Summary

Fixes the silent-cron regression introduced by #157. The injected `scheduled()` handler bridged Worker `env` into `process.env` before calling the bundled `createAdminClient` / `runMainCron` / `runScheduler`. That bridge silently no-ops in workerd: the bundled IIFE shim resolves `process.env` through its own module graph and doesn't see writes made from the injected handler. Result: every cron tick after the #157 deploy threw `supabaseUrl is required` inside our try/catch, Cloudflare counted the invocation as `"ok"`, and `mlb_cron_runs` went silent. SLO B1 fired today because the 9am-ET scheduler couldn't even reach `startRun()` to write a `schedule_running` row.

Production stack trace from the Logs tab confirmed the diagnosis:

```
Cron main handler error: Error: supabaseUrl is required.
  at Object.As [as createAdminClient] (worker.js:138222:12)
  at worker.js:138240:31
  at Object.scheduled (worker.js:138249:7)
```

## What changed

- `createAdminClient(url, key)` accepts explicit args with `process.env` fallback.
- `sendEmail` accepts `{ apiKey, fromEmail }` with `process.env` fallback.
- `buildEmailHtml` / `buildWelcomeEmailHtml` accept `{ siteUrl, tipUrl }` with `process.env` fallback.
- `runMainCron` takes a new `env` arg; when present it builds `emailOpts` / `templateOpts` and threads them to brevo + email-template. HTTP callers (`/api/cron`, admin actions, welcome route) omit `env` and pick up `process.env` via OpenNext's fetch wrapper exactly as before.
- Injected `scheduled()` handler drops the broken `for ... process.env[k] = v` loop and passes `env.NEXT_PUBLIC_SUPABASE_URL` / `env.SUPABASE_SERVICE_ROLE_KEY` directly to `createAdminClient`, plus `env` itself to `runMainCron`.

## Tests

- `inject-scheduled.test.mjs` now asserts `env` is passed explicitly and that the doomed `process.env[k] = v` loop stays gone.
- `brevo.test.js` and `email-template.test.js` each get a test that junks `process.env` to prove explicit option args win — would have caught the original #163.

`vitest run`: 108 passed (was 106; +2 regression-protection tests).

## Test plan

- [ ] Auto-deploy from this PR completes successfully (Cloudflare Workers Build).
- [ ] In the Cloudflare Logs tab, the next `*/15` scheduled invocation has no exception (previously: `supabaseUrl is required` every 15 min).
- [ ] Within one tick, `mlb_cron_runs` gets a new row (either `skipped_no_wake` or a real run status). `/admin` `LAST CRON RUN` drops from "5h ago" to single-digit minutes.
- [ ] Click `/admin` → **Run daily scheduler now** to repopulate today's `mlb_cron_schedule`. A `schedule_built` row should appear; SLO B1 should clear on the next pg_cron check.
- [ ] Click **Run main cron now** to fan out any games that finished during the silent window.
- [ ] Tomorrow's 13:00 UTC tick writes a `schedule_built` row without manual intervention.

## Follow-up worth considering (not in this PR)

The original failure was visible inside our try/catch but invisible to Cloudflare (the cron returned `outcome: "ok"`). SLO B2 didn't trip because Cloudflare *was* invoking the handler — there was just no Supabase write. Adding an alarm on "no `running` or `schedule_running` row inserted in N minutes" would catch this class of bug within ~30 min instead of 26h.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdKEgYUCD3BjTrTqAVUNaH)_