### PR TITLE
Fail fast on missing cron env bindings (#165)

### DIFF
--- a/scripts/inject-scheduled.mjs
+++ b/scripts/inject-scheduled.mjs
@@ -82,6 +82,19 @@ const scheduledHandler = `
         // injected handler (#163). Threading env to each lib is uglier but it
         // actually works.
         const job = event.cron === "0 13 * * *" ? "schedule" : "main";
+        // Fail fast on missing Worker secrets — otherwise the failure surfaces
+        // as "supabaseUrl is required" deep inside the Supabase client, the
+        // try/catch below logs a generic stack, Cloudflare counts the tick as
+        // outcome:ok, and the only signal is SLO B1 firing 26h later (#165).
+        const requiredBindings = ["NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"];
+        const missingBindings = requiredBindings.filter((k) => !env[k]);
+        if (missingBindings.length) {
+            console.error(
+                \`Cron \${job} skipped: missing Worker secret(s): \${missingBindings.join(", ")}. \` +
+                "Set via Cloudflare dashboard → Workers → mlb → Settings → Variables and Secrets."
+            );
+            return;
+        }
         const work = (async () => {
             try {
                 const supabase = cron.createAdminClient(

--- a/scripts/inject-scheduled.test.mjs
+++ b/scripts/inject-scheduled.test.mjs
@@ -118,6 +118,33 @@ describe("inject-scheduled", () => {
     expect(scheduledBlock).not.toContain("Object.entries(env)");
   });
 
+  it("validates required env bindings and names them + the dashboard path (#165)", () => {
+    runInject();
+    const patched = readFileSync(workerPath, "utf-8");
+    const scheduledIdx = patched.indexOf("async scheduled");
+    const scheduledBlock = patched.slice(
+      scheduledIdx,
+      patched.indexOf("async fetch", scheduledIdx)
+    );
+    // Both required secrets must appear in the validation list so missing
+    // either of them produces a named, actionable wrangler-tail message
+    // instead of "supabaseUrl is required" from deep inside @supabase/*.
+    expect(scheduledBlock).toContain('"NEXT_PUBLIC_SUPABASE_URL"');
+    expect(scheduledBlock).toContain('"SUPABASE_SERVICE_ROLE_KEY"');
+    // The skip message must name the missing binding(s) and point to the
+    // dashboard path the operator needs to open to fix it.
+    expect(scheduledBlock).toMatch(/missing Worker secret/);
+    expect(scheduledBlock).toContain(
+      "Cloudflare dashboard → Workers → mlb → Settings → Variables and Secrets"
+    );
+    // Validation must happen before the createAdminClient call — otherwise
+    // the Supabase constructor's own error wins and the named message never
+    // reaches wrangler tail.
+    expect(scheduledBlock.indexOf("missing Worker secret")).toBeLessThan(
+      scheduledBlock.indexOf("createAdminClient")
+    );
+  });
+
   it("is idempotent — running it twice does not double-inject", () => {
     runInject();
     const once = readFileSync(workerPath, "utf-8");


### PR DESCRIPTION
## Summary

- Validates `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` at the top of the injected `scheduled()` handler in `scripts/inject-scheduled.mjs`.
- On missing bindings, logs a named, actionable message (binding name + Cloudflare dashboard path) and early-returns — so the failure shows up in `wrangler tail` on the next 15-min tick instead of waiting for SLO B1 to fire ~26h later.
- Adds a test asserting the validation block is present, names both bindings, includes the dashboard path, and runs before `createAdminClient`.

Early-return (not throw) per the issue's reasoning: Cloudflare doesn't retry `scheduled()` throws, and a thrown error from the handler itself obscures the cause. The `console.error` is what's visible in `wrangler tail`.

Closes #165.

## Test plan

- [x] `npm test` — 109/109 passing (was 108; +1 new test)
- [x] `scripts/inject-scheduled.test.mjs` covers the new validation block and ordering
- [ ] Manual smoke: temporarily unset `NEXT_PUBLIC_SUPABASE_URL` in a non-prod env and confirm `wrangler tail` shows the expected message on the next tick (per acceptance criteria)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3GiQKCfGUT9QYv59wyV2r)_