### PR TITLE
Verify runtime Worker secrets in post-deploy-check (#166)

### DIFF
--- a/scripts/post-deploy-check.mjs
+++ b/scripts/post-deploy-check.mjs
@@ -1,4 +1,4 @@
-// Post-deploy bootstrap + smoke checks. Issue #108.
+// Post-deploy bootstrap + smoke checks. Issue #108, extended in #166.
 //
 // Cloudflare cron triggers fire on schedule, not on registration. A deploy
 // landing after 13:00 UTC creates a window of up to 24h where the daily
@@ -8,10 +8,21 @@
 //   1. POSTing once to /api/cron/schedule so the table is populated immediately.
 //   2. Verifying both expected cron triggers are registered with Cloudflare.
 //   3. Asserting today's schedule has rows when MLB has games today.
+//   4. Cross-checking runtime Worker secrets against CLAUDE.md's canonical list
+//      (#166) — postmortem #164 landed because two NEXT_PUBLIC_SUPABASE_*
+//      values were only in the Build store, not the runtime store.
 //
 // Required env: CRON_SECRET.
 // Optional env: CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID (enables the
-// Cloudflare-side trigger check; without them the script warns and continues).
+// Cloudflare-side trigger + secret checks; without them the script warns and
+// continues).
+
+import { execFileSync } from "node:child_process";
+import {
+  REQUIRED_SECRETS,
+  parseWranglerSecretList,
+  verifySecrets,
+} from "./verify-secrets.mjs";
 
 const SITE_URL = process.env.SITE_URL || "https://ninthinning.email";
 const CRON_SECRET = process.env.CRON_SECRET;
@@ -27,6 +38,7 @@ const EXPECTED_CRONS = ["*/15 * * * *", "0 13 * * *"];
 const BOOTSTRAP_TIMEOUT_MS = 30000;
 const CF_API_TIMEOUT_MS = 10000;
 const MLB_API_TIMEOUT_MS = 8000;
+const WRANGLER_SECRET_LIST_TIMEOUT_MS = 15000;
 
 function fail(msg) {
   console.error(`\npost-deploy: FAIL — ${msg}`);
@@ -121,7 +133,62 @@ if (CF_API_TOKEN && CF_ACCOUNT_ID) {
 }
 
 // ---------------------------------------------------------------------------
-// 3) Assert today's row presence (skip on offseason)
+// 3) Verify runtime Worker secrets match CLAUDE.md (#166)
+// ---------------------------------------------------------------------------
+
+if (CF_API_TOKEN && CF_ACCOUNT_ID) {
+  info("verifying runtime Worker secrets via `wrangler secret list` …");
+  let stdout;
+  try {
+    stdout = execFileSync(
+      "npx",
+      ["wrangler", "secret", "list", "--name", WORKER_NAME, "--format", "json"],
+      {
+        encoding: "utf-8",
+        timeout: WRANGLER_SECRET_LIST_TIMEOUT_MS,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env },
+      },
+    );
+  } catch (err) {
+    fail(
+      `could not list Worker secrets via wrangler: ${err.message}. ` +
+        `Ensure CLOUDFLARE_API_TOKEN has the "Workers Scripts:Edit" permission.`,
+    );
+  }
+
+  let actualNames;
+  try {
+    actualNames = parseWranglerSecretList(stdout);
+  } catch (err) {
+    fail(`could not parse \`wrangler secret list\` output: ${err.message}`);
+  }
+
+  const { missing, extra } = verifySecrets(actualNames);
+  if (missing.length > 0) {
+    fail(
+      `Worker is missing required secret(s): ${missing.join(", ")}. ` +
+        `Set them with \`npx wrangler secret put <NAME>\` and redeploy. ` +
+        `Full rotation runbook: CLAUDE.md → "Secret rotation runbook".`,
+    );
+  }
+  if (extra.length > 0) {
+    warn(
+      `Worker has secret(s) not listed in CLAUDE.md: ${extra.join(", ")}. ` +
+        `If this is an in-flight rotation, ignore. Otherwise update CLAUDE.md ` +
+        `or remove via \`npx wrangler secret delete <NAME>\`.`,
+    );
+  }
+  info(`Worker has all ${REQUIRED_SECRETS.length} required secret(s).`);
+} else {
+  warn(
+    "CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID not set; skipping Worker secret " +
+      "verification. Set both to enable.",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 4) Assert today's row presence (skip on offseason)
 // ---------------------------------------------------------------------------
 
 if (wakeCount > 0) {

--- a/scripts/verify-secrets.mjs
+++ b/scripts/verify-secrets.mjs
@@ -1,0 +1,38 @@
+// Worker-secret verification for post-deploy-check. Issue #166.
+//
+// Canonical source of truth for which Cloudflare Worker secrets the `mlb`
+// Worker is expected to have at runtime. Mirrors the "Configuration: vars vs.
+// secrets" table in CLAUDE.md — keep the two in sync. Postmortem #164 landed
+// because NEXT_PUBLIC_SUPABASE_URL / _ANON_KEY were never added to the runtime
+// store; a deploy-time cross-check against this list would have caught it.
+
+export const REQUIRED_SECRETS = [
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "EMAIL_API_KEY",
+  "CRON_SECRET",
+  "ADMIN_EMAIL",
+];
+
+export const OPTIONAL_SECRETS = [
+  "EMAILS_PAUSED",
+  "NEXT_PUBLIC_POSTHOG_KEY",
+  "NEXT_PUBLIC_POSTHOG_HOST",
+];
+
+export function verifySecrets(actualNames) {
+  const present = new Set(actualNames);
+  const known = new Set([...REQUIRED_SECRETS, ...OPTIONAL_SECRETS]);
+  const missing = REQUIRED_SECRETS.filter((name) => !present.has(name));
+  const extra = actualNames.filter((name) => !known.has(name));
+  return { missing, extra };
+}
+
+export function parseWranglerSecretList(stdout) {
+  const json = JSON.parse(stdout);
+  if (!Array.isArray(json)) {
+    throw new Error("expected an array from `wrangler secret list --format json`");
+  }
+  return json.map((entry) => entry.name);
+}

--- a/scripts/verify-secrets.test.mjs
+++ b/scripts/verify-secrets.test.mjs
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  REQUIRED_SECRETS,
+  OPTIONAL_SECRETS,
+  verifySecrets,
+  parseWranglerSecretList,
+} from "./verify-secrets.mjs";
+
+// Issue #166. Postmortem #164 landed because two Supabase secrets were missing
+// from the runtime store. The deploy-time check has to fail loudly on missing
+// required secrets, but tolerate optional ones being absent and unexpected
+// extras (so an in-flight rotation doesn't block a deploy).
+
+// Real `wrangler secret list --format json` output shape.
+function wranglerOutput(names) {
+  return JSON.stringify(names.map((name) => ({ name, type: "secret_text" })));
+}
+
+describe("parseWranglerSecretList", () => {
+  it("extracts secret names from wrangler's JSON output", () => {
+    const stdout = wranglerOutput(["CRON_SECRET", "EMAIL_API_KEY"]);
+    expect(parseWranglerSecretList(stdout)).toEqual([
+      "CRON_SECRET",
+      "EMAIL_API_KEY",
+    ]);
+  });
+
+  it("returns an empty list when no secrets are set", () => {
+    expect(parseWranglerSecretList("[]")).toEqual([]);
+  });
+
+  it("throws on non-array JSON", () => {
+    expect(() => parseWranglerSecretList('{"oops":true}')).toThrow();
+  });
+});
+
+describe("verifySecrets", () => {
+  it("passes when every required secret is present", () => {
+    const stdout = wranglerOutput([...REQUIRED_SECRETS]);
+    const { missing, extra } = verifySecrets(parseWranglerSecretList(stdout));
+    expect(missing).toEqual([]);
+    expect(extra).toEqual([]);
+  });
+
+  it("flags the Supabase NEXT_PUBLIC_* secrets when they're missing — the exact #164 regression", () => {
+    const stdout = wranglerOutput(
+      REQUIRED_SECRETS.filter(
+        (n) =>
+          n !== "NEXT_PUBLIC_SUPABASE_URL" &&
+          n !== "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      ),
+    );
+    const { missing } = verifySecrets(parseWranglerSecretList(stdout));
+    expect(missing).toContain("NEXT_PUBLIC_SUPABASE_URL");
+    expect(missing).toContain("NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  });
+
+  it("tolerates optional secrets being absent", () => {
+    const stdout = wranglerOutput([...REQUIRED_SECRETS]);
+    const { missing, extra } = verifySecrets(parseWranglerSecretList(stdout));
+    for (const opt of OPTIONAL_SECRETS) {
+      expect(missing).not.toContain(opt);
+      expect(extra).not.toContain(opt);
+    }
+  });
+
+  it("accepts optional secrets when present", () => {
+    const stdout = wranglerOutput([
+      ...REQUIRED_SECRETS,
+      "NEXT_PUBLIC_POSTHOG_KEY",
+      "EMAILS_PAUSED",
+    ]);
+    const { missing, extra } = verifySecrets(parseWranglerSecretList(stdout));
+    expect(missing).toEqual([]);
+    expect(extra).toEqual([]);
+  });
+
+  it("reports unknown secrets as extras without failing the required-check", () => {
+    const stdout = wranglerOutput([...REQUIRED_SECRETS, "LEFTOVER_FROM_OLD_FEATURE"]);
+    const { missing, extra } = verifySecrets(parseWranglerSecretList(stdout));
+    expect(missing).toEqual([]);
+    expect(extra).toEqual(["LEFTOVER_FROM_OLD_FEATURE"]);
+  });
+
+  it("returns missing secrets in a stable, named order so the failure message names them", () => {
+    const { missing } = verifySecrets([]);
+    expect(missing).toEqual(REQUIRED_SECRETS);
+  });
+});


### PR DESCRIPTION
Closes #166. Follow-up from postmortem #164 (action 2 of 4).

## Summary

Postmortem #164 landed because `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` were only in the Build store, never added to the runtime store — the cron read empty env vars for ~26h until the SLO B1 alarm tripped. A `wrangler secret list` cross-check at deploy time would have failed the deploy with a named, actionable message instead.

- `scripts/verify-secrets.mjs` (new) — canonical `REQUIRED_SECRETS` / `OPTIONAL_SECRETS` lists mirroring the CLAUDE.md "Configuration: vars vs. secrets" table, plus pure `verifySecrets()` and `parseWranglerSecretList()` helpers.
- `scripts/post-deploy-check.mjs` — new section 3 shells out to `npx wrangler secret list --name mlb --format json`, parses, and fails on missing required secrets (naming them + pointing to the rotation runbook), warns on unexpected extras so in-flight rotations don't block deploys, and skips with a warning when `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` are unset (matching the existing trigger-check pattern).
- `scripts/verify-secrets.test.mjs` (new) — 9 unit tests including one that explicitly reproduces the #164 missing-Supabase-secrets regression. All 118 tests pass locally.

## Test plan

- [x] `npm test` — 13 files, 118 tests pass (9 new in `verify-secrets.test.mjs`)
- [ ] Deploy with all required secrets present → passes silently
- [ ] Deploy after `wrangler secret delete CRON_SECRET` → fails non-zero, names `CRON_SECRET`, points at the rotation runbook
- [ ] Run with `CLOUDFLARE_API_TOKEN` unset → warns and continues (matches existing trigger-check skip)


---
_Generated by [Claude Code](https://claude.ai/code/session_011mDTM4vB81QvmmqfQ6CRkP)_