### PR TITLE
Batch cron Supabase + MLB calls to stay under subrequest cap

### DIFF
--- a/lib/cron-jobs.js
+++ b/lib/cron-jobs.js
@@ -1,6 +1,5 @@
 import { TEAMS_BY_ID } from "@/lib/teams";
 import {
-  fetchSchedule,
   extractFinalGames,
   fetchGameContent,
   extractHighlightUrl,
@@ -186,10 +185,19 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
 
     const { data: subscribedTeams } = await supabase
       .from("mlb_user_teams")
-      .select("team_id")
+      .select("user_id, team_id")
       .limit(1000);
 
-    const teamIds = [...new Set((subscribedTeams || []).map((r) => r.team_id))];
+    // Group subscribers by team for the email fan-out below, so we don't
+    // re-query mlb_user_teams once per new game.
+    const subscribersByTeamId = new Map();
+    for (const row of subscribedTeams || []) {
+      if (!subscribersByTeamId.has(row.team_id)) {
+        subscribersByTeamId.set(row.team_id, []);
+      }
+      subscribersByTeamId.get(row.team_id).push(row.user_id);
+    }
+    const teamIds = [...subscribersByTeamId.keys()];
 
     if (teamIds.length === 0) {
       await finalizeRun(supabase, runId, "no_subscribers", { errors });
@@ -198,65 +206,90 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
 
     console.log(`Checking ${teamIds.length} teams across dates: ${dates.join(", ")}`);
 
-    const newGames = [];
-
-    for (const teamId of teamIds) {
-      for (const dateStr of dates) {
+    // Fetch one schedule per date instead of one per (team × date). The MLB
+    // Stats API returns all 30 teams' games for a date in a single call, so
+    // we filter locally rather than spending a subrequest per team. This was
+    // the dominant cause of "Too many subrequests by single Worker invocation"
+    // errors on busy MLB days — 30 teams × 3 dates = 90 fetches just here.
+    const teamIdSet = new Set(teamIds);
+    const candidatesByGamePk = new Map();
+    await Promise.all(
+      dates.map(async (dateStr) => {
         try {
-          const schedule = await fetchSchedule(teamId, dateStr);
-          const finals = extractFinalGames(schedule);
-
-          for (const game of finals) {
-            const { data: cached } = await supabase
-              .from("mlb_game_cache")
-              .select("highlight_url")
-              .eq("game_pk", game.gamePk)
-              .single();
-
-            if (cached?.highlight_url) {
-              newGames.push({
-                gamePk: game.gamePk,
-                teamId,
-                gameDate: dateStr,
-                highlightUrl: cached.highlight_url,
-              });
-              continue;
-            }
-
-            const content = await fetchGameContent(game.gamePk);
-            const url = extractHighlightUrl(content);
-
-            await supabase.from("mlb_game_cache").upsert({
-              game_pk: game.gamePk,
-              team_id: teamId,
-              game_date: dateStr,
-              status: "final",
-              highlight_url: url,
-              checked_at: new Date().toISOString(),
-            });
-
-            if (url) {
-              newGames.push({
-                gamePk: game.gamePk,
-                teamId,
-                gameDate: dateStr,
-                highlightUrl: url,
-              });
-            } else {
-              const contentKeys = Object.keys(content || {}).join(", ");
-              const hasHighlights = !!content?.highlights?.highlights?.items?.length;
-              const hasEpg = !!content?.media?.epg?.length;
-              console.log(
-                `No highlight for game ${game.gamePk} (team ${teamId}, date ${dateStr}). ` +
-                  `Content keys: [${contentKeys}], hasLegacyHighlights: ${hasHighlights}, hasEpg: ${hasEpg}`
-              );
-            }
+          const schedule = await fetchDailySchedule(dateStr);
+          for (const game of extractFinalGames(schedule)) {
+            const homeId = game.teams?.home?.team?.id;
+            const awayId = game.teams?.away?.team?.id;
+            const matchedTeamIds = [];
+            if (teamIdSet.has(homeId)) matchedTeamIds.push(homeId);
+            if (teamIdSet.has(awayId)) matchedTeamIds.push(awayId);
+            if (matchedTeamIds.length === 0) continue;
+            // A game can match for both home and away when both fanbases are
+            // subscribed; key by gamePk so we only fetch/cache once.
+            candidatesByGamePk.set(game.gamePk, { dateStr, teamIds: matchedTeamIds });
           }
         } catch (err) {
-          const errMsg = `Error checking team ${teamId} on ${dateStr}: ${err.message}`;
+          const errMsg = `Error fetching schedule for ${dateStr}: ${err.message}`;
           console.error(errMsg);
           errors.push(errMsg);
         }
+      })
+    );
+
+    // Batch the cache lookup: one .in() query instead of one per final game.
+    const candidateGamePks = [...candidatesByGamePk.keys()];
+    const cachedHighlightByPk = new Map();
+    if (candidateGamePks.length > 0) {
+      const { data: cachedRows, error: cacheError } = await supabase
+        .from("mlb_game_cache")
+        .select("game_pk, highlight_url")
+        .in("game_pk", candidateGamePks);
+      if (cacheError) {
+        console.error("mlb_game_cache batch read failed:", cacheError.message);
+      } else {
+        for (const row of cachedRows || []) {
+          cachedHighlightByPk.set(row.game_pk, row.highlight_url);
+        }
+      }
+    }
+
+    const newGames = [];
+    for (const [gamePk, { dateStr, teamIds: matchedTeamIds }] of candidatesByGamePk) {
+      let url;
+      if (cachedHighlightByPk.has(gamePk)) {
+        url = cachedHighlightByPk.get(gamePk);
+      } else {
+        try {
+          const content = await fetchGameContent(gamePk);
+          url = extractHighlightUrl(content);
+          await supabase.from("mlb_game_cache").upsert({
+            game_pk: gamePk,
+            team_id: matchedTeamIds[0],
+            game_date: dateStr,
+            status: "final",
+            highlight_url: url,
+            checked_at: new Date().toISOString(),
+          });
+          if (!url) {
+            const contentKeys = Object.keys(content || {}).join(", ");
+            const hasHighlights = !!content?.highlights?.highlights?.items?.length;
+            const hasEpg = !!content?.media?.epg?.length;
+            console.log(
+              `No highlight for game ${gamePk} (teams ${matchedTeamIds.join(",")}, date ${dateStr}). ` +
+                `Content keys: [${contentKeys}], hasLegacyHighlights: ${hasHighlights}, hasEpg: ${hasEpg}`
+            );
+          }
+        } catch (err) {
+          const errMsg = `Error checking game ${gamePk} on ${dateStr}: ${err.message}`;
+          console.error(errMsg);
+          errors.push(errMsg);
+          continue;
+        }
+      }
+
+      if (!url) continue;
+      for (const teamId of matchedTeamIds) {
+        newGames.push({ gamePk, teamId, gameDate: dateStr, highlightUrl: url });
       }
     }
 
@@ -295,40 +328,65 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
       }
     }
 
+    // Batch the user-email and sent-notification lookups: one .in() query
+    // each, instead of two queries per (game × subscriber). Without this, a
+    // busy MLB day blows past Cloudflare's 1000-subrequest-per-invocation
+    // budget before finalizeRun() can update mlb_cron_runs.
+    const candidateUserIds = new Set();
     for (const game of newGames) {
-      const { data: subscribers } = await supabase
-        .from("mlb_user_teams")
-        .select("user_id")
-        .eq("team_id", game.teamId);
+      for (const userId of subscribersByTeamId.get(game.teamId) || []) {
+        candidateUserIds.add(userId);
+      }
+    }
+    const candidateUserIdList = [...candidateUserIds];
 
-      if (!subscribers?.length) {
+    const emailByUserId = new Map();
+    if (candidateUserIdList.length > 0) {
+      const { data: userRows, error: usersError } = await supabase
+        .from("mlb_users")
+        .select("id, email")
+        .in("id", candidateUserIdList);
+      if (usersError) {
+        console.error("mlb_users batch read failed:", usersError.message);
+      } else {
+        for (const row of userRows || []) {
+          if (row.email) emailByUserId.set(row.id, row.email);
+        }
+      }
+    }
+
+    const newGameGamePks = [...new Set(newGames.map((g) => g.gamePk))];
+    const alreadySent = new Set();
+    if (candidateUserIdList.length > 0 && newGameGamePks.length > 0) {
+      const { data: sentRows, error: sentError } = await supabase
+        .from("mlb_sent_notifications")
+        .select("user_id, game_pk")
+        .in("game_pk", newGameGamePks)
+        .in("user_id", candidateUserIdList);
+      if (sentError) {
+        console.error("mlb_sent_notifications batch read failed:", sentError.message);
+      } else {
+        for (const row of sentRows || []) {
+          alreadySent.add(`${row.user_id}:${row.game_pk}`);
+        }
+      }
+    }
+
+    for (const game of newGames) {
+      const subscriberUserIds = subscribersByTeamId.get(game.teamId) || [];
+      if (subscriberUserIds.length === 0) {
         skipped.push({ gamePk: game.gamePk, reason: "no_subscribers" });
         continue;
       }
 
-      for (const row of subscribers) {
-        const userId = row.user_id;
-
-        const { data: userData } = await supabase
-          .from("mlb_users")
-          .select("email")
-          .eq("id", userId)
-          .single();
-
-        const email = userData?.email;
+      for (const userId of subscriberUserIds) {
+        const email = emailByUserId.get(userId);
         if (!email) {
           skipped.push({ gamePk: game.gamePk, userId, reason: "no_email" });
           continue;
         }
 
-        const { data: existing } = await supabase
-          .from("mlb_sent_notifications")
-          .select("id")
-          .eq("user_id", userId)
-          .eq("game_pk", game.gamePk)
-          .maybeSingle();
-
-        if (existing) {
+        if (alreadySent.has(`${userId}:${game.gamePk}`)) {
           skipped.push({ gamePk: game.gamePk, reason: "already_notified" });
           continue;
         }


### PR DESCRIPTION
## Summary

Fixes the `Too many subrequests by single Worker invocation` errors in `mlb_cron_runs` finalize logs.

Cloudflare Workers cap each invocation at 1000 subrequests. Every external `fetch` and every Supabase query counts. The previous `runMainCron` made:

- one MLB schedule fetch per (team × date) — 30 teams × 3 dates = **90 fetches just here**
- one `mlb_game_cache` query per final game
- per (game × subscriber): one `mlb_users` query + one `mlb_sent_notifications` query

On a busy MLB day the budget was exhausted before `finalizeRun()` could update `mlb_cron_runs` — exactly the failure mode in the reported log line.

## Changes (`lib/cron-jobs.js`)

- `fetchDailySchedule` once per date and filter by subscribed teams locally (3 fetches instead of 3N).
- Dedupe candidates by `gamePk` so a matchup with both fanbases subscribed only fetches game content + upserts cache once.
- Batch `mlb_game_cache`, `mlb_users`, and `mlb_sent_notifications` reads with `.in()`.
- Reuse the already-fetched `mlb_user_teams` rows (now selecting `user_id` too) for the email loop instead of re-querying per game.

Net effect: a fan-out that scaled as `O(teams × dates + games × subscribers)` in subrequests now scales as `O(dates + unique_games + emails_sent)`.

## Test plan

- [x] `npm test` — all 118 tests pass
- [ ] After deploy, watch `mlb_cron_runs` for clean `success` rows on a busy MLB day (no `Failed to finalize` log lines)
- [ ] Confirm `mlb_game_cache` rows still populate for newly-final games
- [ ] Confirm sent emails still land and `mlb_sent_notifications` rows still write


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYfykJxi76rWYP8AARea8b)_