### PR TITLE
Add recap UTM params to "Watch Highlights" CTA (#93)

### DIFF
--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -22,6 +22,32 @@ function getSiteUrl(override) {
   );
 }
 
+// Append our standard recap-email UTM params to a CTA URL so MLB.com
+// clickthroughs (and, eventually, our own highlights landing page) show up
+// in analytics with consistent attribution. Existing params on the input URL
+// win — we never overwrite a value the upstream URL already carries. If the
+// URL fails to parse we return it unchanged rather than breaking the email.
+export function appendUtmParams(url, params = RECAP_CTA_UTM) {
+  if (!url) return url;
+  try {
+    const parsed = new URL(url);
+    for (const [key, value] of Object.entries(params)) {
+      if (!parsed.searchParams.has(key)) {
+        parsed.searchParams.set(key, value);
+      }
+    }
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+const RECAP_CTA_UTM = {
+  utm_source: "ninthinning",
+  utm_medium: "email",
+  utm_campaign: "recap",
+};
+
 export function buildWelcomeEmailHtml(userId, { siteUrl: siteUrlOverride, tipUrl: tipUrlOverride } = {}) {
   const siteUrl = getSiteUrl(siteUrlOverride);
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
@@ -194,6 +220,7 @@ export function buildEmailHtml(
   const teamAbbr = team?.abbr || "";
   const displayDate = formatDisplayDate(gameDate);
   const standingsHtml = renderStandingsStrip(standing, teamColor);
+  const ctaUrl = appendUtmParams(highlightUrl);
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -235,7 +262,7 @@ export function buildEmailHtml(
   <tr><td style="padding:24px 32px 0 32px;">
     <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
       <tr><td align="center">
-        <a href="${highlightUrl}" style="display:inline-block;background-color:${teamColor};color:#ffffff;font-size:16px;font-weight:600;text-decoration:none;padding:14px 36px;border-radius:8px;letter-spacing:0.3px;">Watch Highlights &#9654;</a>
+        <a href="${ctaUrl}" style="display:inline-block;background-color:${teamColor};color:#ffffff;font-size:16px;font-weight:600;text-decoration:none;padding:14px 36px;border-radius:8px;letter-spacing:0.3px;">Watch Highlights &#9654;</a>
       </td></tr>
       <tr><td align="center" style="padding-top:8px;font-size:12px;color:#a1a1aa;">
         Video: <a href="https://www.mlb.com" style="color:#a1a1aa;">MLB.com</a>

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildEmailHtml, buildWelcomeEmailHtml } from "./email-template";
+import { appendUtmParams, buildEmailHtml, buildWelcomeEmailHtml } from "./email-template";
 
 const TEAM = { id: 147, name: "New York Yankees", abbr: "NYY", color: "#003087" };
 const HIGHLIGHT_URL = "https://example.com/highlight.mp4";
@@ -27,9 +27,21 @@ describe("buildEmailHtml", () => {
     expect(html).toContain("#003087");
   });
 
-  it("links the watch button to the highlight URL", () => {
+  it("links the watch button to the highlight URL with recap UTM params (#93)", () => {
     const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE);
-    expect(html).toContain(`href="${HIGHLIGHT_URL}"`);
+    expect(html).toContain(HIGHLIGHT_URL);
+    expect(html).toContain("utm_source=ninthinning");
+    expect(html).toContain("utm_medium=email");
+    expect(html).toContain("utm_campaign=recap");
+  });
+
+  it("preserves any pre-existing UTM params on the highlight URL", () => {
+    const url = "https://www.mlb.com/video/abc?utm_source=mlb";
+    const html = buildEmailHtml(TEAM, url, USER_ID, GAME_DATE);
+    expect(html).toContain("utm_source=mlb");
+    expect(html).not.toContain("utm_source=ninthinning");
+    expect(html).toContain("utm_medium=email");
+    expect(html).toContain("utm_campaign=recap");
   });
 
   it("formats the game date in long-form US style", () => {
@@ -184,6 +196,33 @@ describe("buildEmailHtml", () => {
       expect(ctaIdx).toBeGreaterThan(-1);
       expect(standingsIdx).toBeGreaterThan(ctaIdx);
     });
+  });
+});
+
+describe("appendUtmParams", () => {
+  it("appends recap UTM params to a bare URL", () => {
+    const out = appendUtmParams("https://www.mlb.com/video/abc");
+    const parsed = new URL(out);
+    expect(parsed.searchParams.get("utm_source")).toBe("ninthinning");
+    expect(parsed.searchParams.get("utm_medium")).toBe("email");
+    expect(parsed.searchParams.get("utm_campaign")).toBe("recap");
+  });
+
+  it("does not overwrite existing UTM keys", () => {
+    const out = appendUtmParams("https://www.mlb.com/x?utm_campaign=custom");
+    const parsed = new URL(out);
+    expect(parsed.searchParams.get("utm_campaign")).toBe("custom");
+    expect(parsed.searchParams.get("utm_source")).toBe("ninthinning");
+  });
+
+  it("returns the input unchanged when the URL fails to parse", () => {
+    expect(appendUtmParams("not a url")).toBe("not a url");
+  });
+
+  it("returns null/empty inputs unchanged", () => {
+    expect(appendUtmParams("")).toBe("");
+    expect(appendUtmParams(null)).toBe(null);
+    expect(appendUtmParams(undefined)).toBe(undefined);
   });
 });
 


### PR DESCRIPTION
Closes #93.

## Summary
- Tag every cron-email "Watch Highlights" CTA URL with `utm_source=ninthinning`, `utm_medium=email`, `utm_campaign=recap` so MLB.com clickthroughs (and the future branded landing page from #77) attribute back to the recap email in analytics.
- New `appendUtmParams(url, params)` helper in `lib/email-template.js`. Pre-existing UTM keys on the upstream URL are preserved — we only fill in keys that aren't already set. Unparseable inputs (and `null` / `""` / `undefined`) pass through unchanged so a bad URL can't break the email.
- Welcome email is unaffected; the CTA there points at `/dashboard` and doesn't need attribution params.

## Test plan
- [x] `npm test` — 13 files, 123 passed (was 118; +5 new assertions/cases)
- [x] Replaced the exact-href assertion in `buildEmailHtml` with one that checks the URL plus the three UTM keys
- [x] Added a "doesn't clobber an upstream `utm_source`" case
- [x] Added four direct tests for `appendUtmParams` (bare URL, existing-key preservation, parse failure, null/empty inputs)

---
_Generated by [Claude Code](https://claude.ai/code/session_014X2PnESue4D6Rk76LdVxfN)_