### PR TITLE
docs: document Brevo SMTP credential rotation (#99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,16 @@ npx wrangler secret list   # should match the secrets table above
 
 If a secret is missing or extra, fix it before merging — missing-secret regressions have caused outages before (cf. issue #65).
 
+### Credentials managed outside the worker
+
+Not every long-lived credential lives in Cloudflare. Some are consumed by Supabase or other upstreams and are configured in their dashboards instead — `wrangler secret list` will not show them and `npm run deploy` will not touch them, but they are on the same quarterly rotation cadence as the Worker secrets above.
+
+| Name | Used by | Where it lives upstream | Notes |
+|------|---------|-------------------------|-------|
+| **Brevo SMTP key** | Supabase Auth (magic-link sender, see #97) | Supabase dashboard → Project Settings → Auth → SMTP Settings → Password | **Not** a Worker secret. Distinct from the transactional `EMAIL_API_KEY` used by `lib/brevo.js` — different Brevo credential type (SMTP key vs. API key), even though both bill against the same Brevo plan quota. Minted in Brevo → SMTP & API → SMTP. |
+
+Failure mode worth flagging: when this credential is bad (expired, revoked, mistyped), Supabase Auth returns the **same** "check your email" response to the user that a successful send does. There is no Worker-side error path because our worker never sees the SMTP call. The only signal is users reporting missing magic links — so any "auth broken" on-call escalation should include a test magic-link send as an early diagnostic step.
+
 ### Build store vs. runtime store: `NEXT_PUBLIC_*` lives in both
 
 `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` have **two consumers on two different read paths**, and each path reads from a different Cloudflare store. Both stores must hold the value or production breaks in subtle ways. This is the worked example from postmortem #164.
@@ -127,7 +137,7 @@ When provisioning a new project or rotating these values, **set them in both sto
 
 ## Secret rotation runbook
 
-Target: any individual secret can be rotated end-to-end in **≤ 30 minutes** with zero email loss. Run through this list dry once per quarter so the steps stay current.
+Target: any individual secret can be rotated end-to-end in **≤ 30 minutes** with zero email loss. Run through this list dry once per quarter so the steps stay current — that quarterly dry-run covers both the Worker secrets below **and** the Brevo SMTP key (see "Credentials managed outside the worker" above), which follows a separate Supabase-dashboard flow documented further down.
 
 General flow for every secret:
 
@@ -145,6 +155,16 @@ Per-secret specifics:
 - **`EMAIL_API_KEY`** — Brevo → SMTP & API → API keys → "Create a new API key", then delete the old key after step 4.
 - **`CRON_SECRET`** — `openssl rand -hex 32` locally → `wrangler secret put CRON_SECRET` → deploy. The cron only calls itself, so there is no third party to update.
 - **`TIP_URL`** *(not a secret, but rotated similarly)* — Edit `wrangler.jsonc` and redeploy.
+
+For the **Brevo SMTP key** (managed in the Supabase dashboard, not as a Worker secret — see "Credentials managed outside the worker" above), the general flow above does **not** apply: there is nothing to `wrangler secret put` and no `npm run deploy` step. Follow this block instead:
+
+1. **Mint** a new SMTP key in Brevo → SMTP & API → SMTP → "Generate a new SMTP key". Do not revoke the old one yet.
+2. **Paste** it into Supabase dashboard → Project Settings → Auth → SMTP Settings → Password, then click Save. No deploy needed — Supabase picks up the new value on the next sign-in attempt.
+3. **Verify** by sending a test magic link: Supabase dashboard → Authentication → Users → pick your row → "Send magic link". Confirm the email arrives from `Ninth Inning Email <highlights@ninthinning.email>` and that the link signs you in successfully. (Sending a real magic link from `/login` works too, but routes through our rate limiters.)
+4. **Revoke** the old SMTP key in Brevo → SMTP & API → SMTP.
+5. **Record** the rotation in `INCIDENT.md` under "Incident log" with the date and reason.
+
+Outage window for this credential is the gap between step 1 and step 2: existing in-flight magic-link sends keep working on the old key until you save the new one, and Supabase swallows any SMTP error into the same "check your email" UI (see failure-mode note above), so a botched paste is silent — that's why step 3 verifies a real send rather than trusting the dashboard.
 
 If you suspect a leak rather than a routine rotation, also: review `wrangler tail` for unauthorized requests over the last 24h, set `EMAILS_PAUSED=true` per `INCIDENT.md` if the leaked secret could send mail, and open an incident issue.
 


### PR DESCRIPTION
Closes #99.

## Summary

Adds documented rotation procedure for the Brevo SMTP credential used by Supabase Auth (introduced in #97). Previously the only Brevo credential covered by the rotation runbook was the transactional `EMAIL_API_KEY`; the SMTP key — managed in the Supabase dashboard, not as a Worker secret — was undocumented and would have been skipped on any quarterly review or leak response.

## Changes to `CLAUDE.md`

- New **"Credentials managed outside the worker"** subsection with a table entry for the Brevo SMTP key. Clearly notes it is **not** a Worker secret, distinguishes it from `EMAIL_API_KEY` (different Brevo credential type, same plan quota), and points to the Supabase dashboard path.
- Flags the silent-failure mode: Supabase Auth returns the same "check your email" response whether or not SMTP actually delivered, so the only signal of a bad key is users reporting missing magic links. Recommends a test magic-link as an early diagnostic in any "auth broken" on-call escalation.
- New numbered rotation block in the secret rotation runbook (mint in Brevo → paste into Supabase dashboard → verify via test magic link → revoke old key → record in `INCIDENT.md`). Notes that the general `wrangler secret put` + `npm run deploy` flow does not apply here.
- Updates the quarterly dry-run intro so the Brevo SMTP key is explicitly in scope alongside the Worker secrets.

## Acceptance criteria (from #99)

- [x] `CLAUDE.md` lists the Brevo SMTP key as a tracked credential with a clear "lives in Supabase dashboard, not a Worker secret" note
- [x] The rotation runbook contains a Brevo-SMTP-specific block following the same numbered-step format as the existing entries
- [x] A reader who has never touched the auth pipeline can rotate the credential from the runbook alone, without referring to #97 or this issue

## Test plan

- [x] `npm run test` — 13 files / 123 tests pass (docs-only change, no code touched)
- [ ] Manual read-through of the rendered `CLAUDE.md` on GitHub to confirm formatting


---
_Generated by [Claude Code](https://claude.ai/code/session_01SJGtNDBnmnXp5SW3NCLNw9)_