### PR TITLE
Add opponent + series context line to recap emails (#69)

### DIFF
--- a/lib/cron-jobs.js
+++ b/lib/cron-jobs.js
@@ -11,6 +11,7 @@ import {
   getEtTodayDate,
   fetchStandings,
   extractTeamStanding,
+  extractSeriesContext,
 } from "@/lib/mlb";
 import { buildEmailHtml } from "@/lib/email-template";
 import { sendEmail } from "@/lib/brevo";
@@ -225,8 +226,10 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
             if (teamIdSet.has(awayId)) matchedTeamIds.push(awayId);
             if (matchedTeamIds.length === 0) continue;
             // A game can match for both home and away when both fanbases are
-            // subscribed; key by gamePk so we only fetch/cache once.
-            candidatesByGamePk.set(game.gamePk, { dateStr, teamIds: matchedTeamIds });
+            // subscribed; key by gamePk so we only fetch/cache once. Keep the
+            // schedule game payload around so the render loop can pull
+            // spoiler-safe series context (#69) without re-fetching.
+            candidatesByGamePk.set(game.gamePk, { dateStr, teamIds: matchedTeamIds, game });
           }
         } catch (err) {
           const errMsg = `Error fetching schedule for ${dateStr}: ${err.message}`;
@@ -254,7 +257,7 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
     }
 
     const newGames = [];
-    for (const [gamePk, { dateStr, teamIds: matchedTeamIds }] of candidatesByGamePk) {
+    for (const [gamePk, { dateStr, teamIds: matchedTeamIds, game: scheduleGame }] of candidatesByGamePk) {
       let url;
       if (cachedHighlightByPk.has(gamePk)) {
         url = cachedHighlightByPk.get(gamePk);
@@ -289,7 +292,7 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
 
       if (!url) continue;
       for (const teamId of matchedTeamIds) {
-        newGames.push({ gamePk, teamId, gameDate: dateStr, highlightUrl: url });
+        newGames.push({ gamePk, teamId, gameDate: dateStr, highlightUrl: url, scheduleGame });
       }
     }
 
@@ -396,13 +399,23 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
         const subject = `${teamName} Highlights — ${formatDisplayDate(game.gameDate)}`;
         const standings = standingsByDate.get(game.gameDate);
         const standing = standings ? extractTeamStanding(standings, game.teamId) : null;
+        const rawSeries = extractSeriesContext(game.scheduleGame, game.teamId);
+        const opponent = rawSeries ? TEAMS_BY_ID[rawSeries.opponentId] : null;
+        const seriesContext = opponent
+          ? {
+              opponentName: opponent.shortName,
+              isHome: rawSeries.isHome,
+              seriesGameNumber: rawSeries.seriesGameNumber,
+              gamesInSeries: rawSeries.gamesInSeries,
+            }
+          : null;
         const html = buildEmailHtml(
           team,
           game.highlightUrl,
           userId,
           game.gameDate,
           standing,
-          templateOpts
+          { ...(templateOpts || {}), seriesContext }
         );
 
         try {

--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -204,13 +204,33 @@ function ordinal(n) {
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }
 
+// Spoiler-safe series context line (#69). Shows `vs Yankees — Game 2 of 3`
+// for home games or `@ Yankees — Game 2 of 3` for away games. Renders nothing
+// if opponent name or series numbers are missing/malformed.
+function renderSeriesContextLine(seriesContext) {
+  if (!seriesContext) return "";
+  const { opponentName, isHome, seriesGameNumber, gamesInSeries } = seriesContext;
+  if (!opponentName) return "";
+  if (!Number.isInteger(seriesGameNumber) || seriesGameNumber < 1) return "";
+  if (!Number.isInteger(gamesInSeries) || gamesInSeries < 1) return "";
+  if (seriesGameNumber > gamesInSeries) return "";
+
+  const prefix = isHome ? "vs" : "@";
+  const line = `${prefix} ${opponentName} &mdash; Game ${seriesGameNumber} of ${gamesInSeries}`;
+  return `
+  <!-- Series context (spoiler-safe: opponent + series position only) -->
+  <tr><td style="padding:14px 32px 0 32px;">
+    <p style="margin:0;font-size:13px;font-weight:600;letter-spacing:0.04em;color:#71717a;text-transform:uppercase;">${line}</p>
+  </td></tr>`;
+}
+
 export function buildEmailHtml(
   team,
   highlightUrl,
   userId,
   gameDate,
   standing = null,
-  { siteUrl: siteUrlOverride, tipUrl: tipUrlOverride } = {}
+  { siteUrl: siteUrlOverride, tipUrl: tipUrlOverride, seriesContext = null } = {}
 ) {
   const siteUrl = getSiteUrl(siteUrlOverride);
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
@@ -220,6 +240,7 @@ export function buildEmailHtml(
   const teamAbbr = team?.abbr || "";
   const displayDate = formatDisplayDate(gameDate);
   const standingsHtml = renderStandingsStrip(standing, teamColor);
+  const seriesContextHtml = renderSeriesContextLine(seriesContext);
   const ctaUrl = appendUtmParams(highlightUrl);
 
   return `<!DOCTYPE html>
@@ -258,6 +279,7 @@ export function buildEmailHtml(
     <p style="margin:8px 0 0 0;font-size:15px;color:#52525b;line-height:1.5;">Your spoiler-free game recap is waiting for you.</p>
   </td></tr>
 
+  ${seriesContextHtml}
   <!-- CTA Button -->
   <tr><td style="padding:24px 32px 0 32px;">
     <table role="presentation" cellpadding="0" cellspacing="0" width="100%">

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -197,6 +197,92 @@ describe("buildEmailHtml", () => {
       expect(standingsIdx).toBeGreaterThan(ctaIdx);
     });
   });
+
+  describe("series context line (#69)", () => {
+    const SERIES_HOME = {
+      opponentName: "Yankees",
+      isHome: true,
+      seriesGameNumber: 2,
+      gamesInSeries: 3,
+    };
+    const SERIES_AWAY = {
+      opponentName: "Red Sox",
+      isHome: false,
+      seriesGameNumber: 1,
+      gamesInSeries: 4,
+    };
+
+    it("renders `vs Opponent — Game X of Y` for a home game", () => {
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, null, {
+        seriesContext: SERIES_HOME,
+      });
+      expect(html).toContain("vs Yankees &mdash; Game 2 of 3");
+    });
+
+    it("renders `@ Opponent — Game X of Y` for an away game", () => {
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, null, {
+        seriesContext: SERIES_AWAY,
+      });
+      expect(html).toContain("@ Red Sox &mdash; Game 1 of 4");
+    });
+
+    it("renders the line above the Watch Highlights CTA", () => {
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, null, {
+        seriesContext: SERIES_HOME,
+      });
+      const seriesIdx = html.indexOf("vs Yankees");
+      const ctaIdx = html.indexOf("Watch Highlights");
+      expect(seriesIdx).toBeGreaterThan(-1);
+      expect(ctaIdx).toBeGreaterThan(-1);
+      expect(seriesIdx).toBeLessThan(ctaIdx);
+    });
+
+    it("omits the line when seriesContext is null or undefined", () => {
+      const htmlNull = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, null, {
+        seriesContext: null,
+      });
+      const htmlUndef = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE);
+      for (const html of [htmlNull, htmlUndef]) {
+        expect(html).not.toContain("Game 1 of");
+        expect(html).not.toContain("Game 2 of");
+        expect(html).not.toMatch(/(>|\s)vs [A-Z]/);
+        expect(html).not.toMatch(/(>|\s)@ [A-Z]/);
+      }
+    });
+
+    it("omits the line when opponentName is missing", () => {
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, null, {
+        seriesContext: { ...SERIES_HOME, opponentName: null },
+      });
+      expect(html).not.toContain("Game 2 of 3");
+    });
+
+    it("omits the line when series numbers are missing or malformed", () => {
+      const cases = [
+        { ...SERIES_HOME, seriesGameNumber: null },
+        { ...SERIES_HOME, gamesInSeries: null },
+        { ...SERIES_HOME, seriesGameNumber: 0 },
+        { ...SERIES_HOME, gamesInSeries: 0 },
+        { ...SERIES_HOME, seriesGameNumber: "two" },
+        { ...SERIES_HOME, seriesGameNumber: 5, gamesInSeries: 3 },
+      ];
+      for (const seriesContext of cases) {
+        const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, null, {
+          seriesContext,
+        });
+        expect(html).not.toContain("Yankees &mdash; Game");
+      }
+    });
+
+    it("never leaks score, win/loss, or play-by-play language", () => {
+      // "inning" is excluded since it's part of the brand name (Ninth Inning Email).
+      const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, null, {
+        seriesContext: SERIES_HOME,
+      });
+      const body = html.toLowerCase();
+      expect(body).not.toMatch(/\b(score|won|lost|walkoff|walk-off|homer|home run)\b/);
+    });
+  });
 });
 
 describe("appendUtmParams", () => {

--- a/lib/mlb.js
+++ b/lib/mlb.js
@@ -198,6 +198,26 @@ function shortenDivisionName(name) {
     .replace(/^National League\s+/i, "NL ");
 }
 
+// Spoiler-safe series context for the recap email (issue #69). Returns the
+// rooting team's perspective: opponent id, home/away, and the game's position
+// in the series. Numbers are normalized to ints; anything missing or malformed
+// returns null so the template can omit the line cleanly.
+export function extractSeriesContext(game, teamId) {
+  if (!game || !teamId) return null;
+  const homeId = game?.teams?.home?.team?.id;
+  const awayId = game?.teams?.away?.team?.id;
+  if (homeId !== teamId && awayId !== teamId) return null;
+  const isHome = homeId === teamId;
+  const opponentId = isHome ? awayId : homeId;
+  if (!opponentId) return null;
+  return {
+    opponentId,
+    isHome,
+    seriesGameNumber: toIntOrNull(game.seriesGameNumber),
+    gamesInSeries: toIntOrNull(game.gamesInSeries),
+  };
+}
+
 export function formatDisplayDate(dateStr) {
   const [year, month, day] = dateStr.split("-").map(Number);
   const date = new Date(year, month - 1, day);

--- a/lib/mlb.test.js
+++ b/lib/mlb.test.js
@@ -12,6 +12,7 @@ import {
   formatDisplayDate,
   fetchStandings,
   extractTeamStanding,
+  extractSeriesContext,
   EXPECTED_GAME_DURATION_HOURS,
 } from "./mlb";
 
@@ -405,6 +406,63 @@ describe("extractTeamStanding", () => {
       ],
     };
     expect(extractTeamStanding(nl, 121).divisionName).toBe("NL East");
+  });
+});
+
+describe("extractSeriesContext", () => {
+  const HOME_GAME = {
+    teams: {
+      home: { team: { id: 147 } },
+      away: { team: { id: 111 } },
+    },
+    seriesGameNumber: 2,
+    gamesInSeries: 3,
+  };
+
+  it("returns isHome=true with the away team as opponent for the home team", () => {
+    expect(extractSeriesContext(HOME_GAME, 147)).toEqual({
+      opponentId: 111,
+      isHome: true,
+      seriesGameNumber: 2,
+      gamesInSeries: 3,
+    });
+  });
+
+  it("returns isHome=false with the home team as opponent for the away team", () => {
+    expect(extractSeriesContext(HOME_GAME, 111)).toEqual({
+      opponentId: 147,
+      isHome: false,
+      seriesGameNumber: 2,
+      gamesInSeries: 3,
+    });
+  });
+
+  it("coerces stringified series numbers to ints", () => {
+    const game = { ...HOME_GAME, seriesGameNumber: "1", gamesInSeries: "4" };
+    expect(extractSeriesContext(game, 147)).toMatchObject({
+      seriesGameNumber: 1,
+      gamesInSeries: 4,
+    });
+  });
+
+  it("returns null when teamId is not part of the game", () => {
+    expect(extractSeriesContext(HOME_GAME, 999)).toBe(null);
+  });
+
+  it("returns null when game or teamId is missing", () => {
+    expect(extractSeriesContext(null, 147)).toBe(null);
+    expect(extractSeriesContext(HOME_GAME, null)).toBe(null);
+    expect(extractSeriesContext(undefined, undefined)).toBe(null);
+  });
+
+  it("returns null series numbers when payload is missing them", () => {
+    const game = { teams: HOME_GAME.teams };
+    expect(extractSeriesContext(game, 147)).toEqual({
+      opponentId: 111,
+      isHome: true,
+      seriesGameNumber: null,
+      gamesInSeries: null,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #69 (first scope item).

Recap emails now show a spoiler-safe context line above the Watch Highlights CTA so the recipient knows what game the highlight is for without learning the result:

- Home game: `vs Yankees — Game 2 of 3`
- Away game: `@ Red Sox — Game 1 of 4`

Data comes from the schedule payload the cron already fetches — no extra MLB API calls. The opponent's short name is resolved from `TEAMS_BY_ID`, so display reads naturally (`Yankees`, not `New York Yankees`).

## Changes

- **`lib/mlb.js`** — new `extractSeriesContext(game, teamId)` helper. Returns `{ opponentId, isHome, seriesGameNumber, gamesInSeries }` or `null` when the team isn't part of the game / data is missing.
- **`lib/email-template.js`** — `buildEmailHtml` accepts a `seriesContext` option and renders the line via `renderSeriesContextLine`. Omits the line entirely if any required field is missing/malformed — never throws.
- **`lib/cron-jobs.js`** — threads the schedule game object through to the render loop, resolves opponent name from `TEAMS_BY_ID`, and passes the structured context into `buildEmailHtml`.
- **Tests** — +13 (8 template + 5 helper). Full suite 136/136 passing.

## Deferred

The second scope item in #69 (highlight reel duration `Highlights · ~5 min`) is **not** included. Duration lives in the MLB content API, which the cron only hits on cache miss — showing it consistently would require a new column in `mlb_game_cache` and a backfill plan. Worth its own issue if you want it.

## Test plan

- [x] `npm test` — 13 test files, 136 tests passing
- [ ] Inspect a real recap email after the next live game finish to confirm the line renders correctly and doesn't leak any score/result information

https://claude.ai/code/session_01U5vk7BrW5HjWowzkenR3Wu

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5vk7BrW5HjWowzkenR3Wu)_