### PR TITLE
Make the tip CTA prominent in recap + welcome emails (#83)

### DIFF
--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -118,16 +118,20 @@ export function buildWelcomeEmailHtml(userId, { siteUrl: siteUrlOverride, tipUrl
   </td></tr>
 
   ${tipUrl ? `
-  <!-- Tip prompt -->
-  <tr><td align="center" style="padding:18px 32px 0 32px;">
-    <p style="margin:0;font-size:13px;color:#52525b;line-height:1.5;">
-      Enjoying Ninth Inning Email? <a href="${tipUrl}" style="color:${accent};text-decoration:underline;font-weight:600;">Tip the developer</a> to keep it running.
-    </p>
+  <!-- Tip prompt (#83: prominent card with button-styled CTA) -->
+  <tr><td style="padding:20px 32px 0 32px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border:1px solid #e4e4e7;border-left:3px solid ${accent};border-radius:6px;">
+      <tr><td style="padding:16px 18px;">
+        <p style="margin:0 0 4px 0;font-family:'General Sans','Hanken Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:15px;font-weight:600;color:#1a1d1c;line-height:1.4;">Enjoying Ninth Inning Email?</p>
+        <p style="margin:0 0 12px 0;font-size:13px;color:#52525b;line-height:1.5;">Tips keep the servers running and the recaps free.</p>
+        <a href="${tipUrl}" style="display:inline-block;background-color:${accent};color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:10px 22px;border-radius:6px;letter-spacing:0.3px;">Tip the developer &#9829;</a>
+      </td></tr>
+    </table>
   </td></tr>
   ` : ""}
 
   <!-- Forward prompt -->
-  <tr><td align="center" style="padding:12px 32px 0 32px;">
+  <tr><td align="center" style="padding:16px 32px 0 32px;">
     <p style="margin:0;font-size:13px;color:#52525b;line-height:1.5;">
       Know a fan who&#39;d like this? Forward them this email or send them <a href="${siteUrl}" style="color:${accent};text-decoration:underline;font-weight:600;">ninthinning.email</a>.
     </p>
@@ -299,16 +303,20 @@ export function buildEmailHtml(
   </td></tr>
 
   ${tipUrl ? `
-  <!-- Tip prompt -->
-  <tr><td align="center" style="padding:18px 32px 0 32px;">
-    <p style="margin:0;font-size:13px;color:#52525b;line-height:1.5;">
-      Enjoying Ninth Inning Email? <a href="${tipUrl}" style="color:${teamColor};text-decoration:underline;font-weight:600;">Tip the developer</a> to keep it running.
-    </p>
+  <!-- Tip prompt (#83: prominent card with button-styled CTA) -->
+  <tr><td style="padding:20px 32px 0 32px;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border:1px solid #e4e4e7;border-left:3px solid ${teamColor};border-radius:6px;">
+      <tr><td style="padding:16px 18px;">
+        <p style="margin:0 0 4px 0;font-family:'General Sans','Hanken Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:15px;font-weight:600;color:#1a1d1c;line-height:1.4;">Enjoying Ninth Inning Email?</p>
+        <p style="margin:0 0 12px 0;font-size:13px;color:#52525b;line-height:1.5;">Tips keep the servers running and the recaps free.</p>
+        <a href="${tipUrl}" style="display:inline-block;background-color:${teamColor};color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;padding:10px 22px;border-radius:6px;letter-spacing:0.3px;">Tip the developer &#9829;</a>
+      </td></tr>
+    </table>
   </td></tr>
   ` : ""}
 
   <!-- Forward prompt -->
-  <tr><td align="center" style="padding:12px 32px 0 32px;">
+  <tr><td align="center" style="padding:16px 32px 0 32px;">
     <p style="margin:0;font-size:13px;color:#52525b;line-height:1.5;">
       Know a fan who&#39;d like this? Forward them this email or send them <a href="${siteUrl}" style="color:${teamColor};text-decoration:underline;font-weight:600;">ninthinning.email</a>.
     </p>


### PR DESCRIPTION
Closes #83.

## Summary
- Replaces the small inline "Tip the developer" text link buried near the footer of both the recap and welcome emails with a bordered card containing a heading, short explainer, and a button-styled CTA.
- Recap card uses the team color accent; welcome card uses brand green. Same visual language as the existing primary CTA buttons (Watch Highlights / Manage your teams).
- Phrase "Tip the developer" is preserved so existing template tests still pass.

## Test plan
- [x] `npm test` — 136/136 passing
- [ ] Manual visual check: send a test recap to the admin via `/admin → Resend latest recap to me` and confirm the new card renders correctly in Gmail / Apple Mail
- [ ] Confirm tip card is hidden when `TIP_URL` is unset (existing branch preserved)


---
_Generated by [Claude Code](https://claude.ai/code/session_019szdS2WAdyVsAe7BsmaSuo)_