### PR TITLE
Expand test coverage: end-to-end dry-run testing for the cron pipeline (#180)

### DIFF
--- a/.github/workflows/dry-run-staging.yml
+++ b/.github/workflows/dry-run-staging.yml
@@ -1,0 +1,35 @@
+name: dry-run-staging
+
+# Automated end-to-end dry-run of the cron pipeline against the staging
+# Supabase project (#180). Separate from the `test` workflow on purpose: this
+# makes live MLB Stats API + staging-Supabase calls, so it must not gate the
+# deterministic test suite. Keep it an informational (non-required) check
+# until staging has proven stable.
+#
+# Requires two repository secrets — SUPABASE_STAGING_URL and
+# SUPABASE_STAGING_SERVICE_ROLE_KEY. When they are absent (forks, or before
+# staging is provisioned) the test self-skips and the job passes green.
+
+on:
+  pull_request:
+  schedule:
+    # 13:30 UTC daily (~9:30am ET) — after the previous night's MLB slate has
+    # gone final, so the dry-run has real completed games to fan out against.
+    - cron: "30 13 * * *"
+
+jobs:
+  dry-run-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run test:staging
+        env:
+          SUPABASE_STAGING_URL: ${{ secrets.SUPABASE_STAGING_URL }}
+          SUPABASE_STAGING_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_STAGING_SERVICE_ROLE_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,38 @@ All run as Next.js Server Actions. Auth is the existing admin session check: the
 
 Recovery time goes from ~10 min (rotate `CRON_SECRET`, then DevTools fetch) to ~30 sec (open `/admin`, click button). The 2026-05-02 incident in `INCIDENT.md` is the canonical example of why this matters: not having `CRON_SECRET` saved blocked recovery for the first ~10 min.
 
+## Staging dry-run automation (#180)
+
+`runMainCron`'s dry-run mode is also wired to an isolated **staging Supabase project** so the full pipeline can be smoke-tested against a real database — real PostgREST queries, real RLS-bypass, real `mlb_game_cache` upserts — not just the mocked fixtures in `lib/cron-jobs.integration.test.js`. This is the automated layer that catches bugs only a real database surfaces: query-shape errors, client misconfiguration, PostgREST incompatibilities.
+
+### Layout
+
+| Piece | Role |
+|-------|------|
+| `lib/cron-jobs.staging.test.js` | Runs `runMainCron({ force: true, dryRun: true })` against the staging project + the live MLB Stats API, with only the Brevo send stubbed (stubbed to *throw*, so a regression that tried to send fails loudly). A live smoke test — asserts the pipeline completes end-to-end and finalizes with status `dry_run`, not a specific set of emails (report contents depend on MLB's actual slate). |
+| `createStagingClient()` in `lib/supabase-admin.js` | Service-role client for the staging project; returns `null` when the staging env vars are unset. |
+| `supabase/staging-seed.sql` | Fixture seed — run once, after `supabase-schema.sql`: a superfan subscribed to all 30 teams plus a two-team subscriber, so whichever games MLB actually played, the fan-out is exercised. |
+| `vitest.staging.config.mjs` | Dedicated vitest config; the staging test is **excluded** from the default config so `npm test` stays deterministic. |
+| `.github/workflows/dry-run-staging.yml` | Runs `npm run test:staging` on every PR and daily at 13:30 UTC. |
+
+### Why it is separate from `npm test`
+
+The staging test is **excluded** from the default `npm test` / `predeploy` gate (see the `exclude` glob in `vitest.config.mjs`) and runs only via `npm run test:staging`. It makes live network calls to the MLB API, so keeping it out of the deterministic gate means MLB API flakiness can never block a deploy. `lib/cron-jobs.integration.test.js` stays the always-on gate; the staging dry-run is the live-infra smoke test layered on top.
+
+When `SUPABASE_STAGING_URL` / `SUPABASE_STAGING_SERVICE_ROLE_KEY` are unset the suite skips cleanly — so the CI job is green on forks and before staging is provisioned.
+
+### One-time setup
+
+1. Create a **free-tier Supabase project** — this is the staging project, kept entirely separate from production.
+2. Run `supabase-schema.sql` against it, then `supabase/staging-seed.sql`. (The SLO-alarm `pg_cron`/`pg_net`/Vault setup at the bottom of the schema is production-only — it is harmless on staging but does not need its Vault secrets.)
+3. Add two **GitHub Actions repository secrets**: `SUPABASE_STAGING_URL` and `SUPABASE_STAGING_SERVICE_ROLE_KEY` (the staging project's URL and service-role key). Set the same two as local env vars to run `npm run test:staging` from your machine.
+
+These two values are **not** Worker secrets and are never read by production — they exist only for the CI dry-run, so they do not belong in the `wrangler secret list` check. Keep `dry-run-staging` an informational (non-required) check until staging has proven stable; the deterministic `test` job is the hard merge gate.
+
+### Housekeeping
+
+Each staging dry-run inserts an `mlb_cron_runs` row and upserts `mlb_game_cache` rows into the staging project. Nothing prunes them — on the free tier this is harmless for a long time; truncate the two tables in the staging project if they ever get noisy.
+
 ## Out-of-band SLO alarms (#107)
 
 The `/admin` banner is passive — it only helps if the operator looks. A pg_cron job inside Supabase runs every 5 minutes and emails `ADMIN_EMAIL` directly when either silent-failure SLO trips:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,17 +250,19 @@ Failure modes worth knowing:
 - **Game runs longer than 6h** (extra innings + rain) → the polling window expires and the every-15-min cron stops checking. The next day's scheduler doesn't re-add yesterday's games, but the existing `getDatesToCheck` helper in `lib/mlb.js` keeps the *full-run* path looking back 2 days, so the **next** valid wake (a different team's game today) will catch the late finisher when it runs the fan-out.
 - **DST**: `0 13 * * *` UTC is 9am EDT (most of the MLB regular season) and 8am EST (March/late-October). Both are fine — early-morning is the goal, not exactly 9am.
 
-`mlb_cron_runs` statuses to expect from this stack: `running`, `success`, `partial`, `failure`, `paused`, `no_subscribers`, `no_new_highlights`, `skipped_no_wake` (main cron) and `schedule_running`, `schedule_built`, `schedule_partial`, `schedule_failure` (scheduler). Per postmortem #103 / #104, every `*/15` tick now writes exactly one row — silence is treated as a failure mode, so an empty `mlb_cron_runs` hour means the cron itself isn't running and should page, not "no game in window."
+`mlb_cron_runs` statuses to expect from this stack: `running`, `success`, `partial`, `failure`, `paused`, `no_subscribers`, `no_new_highlights`, `skipped_no_wake`, `dry_run` (main cron) and `schedule_running`, `schedule_built`, `schedule_partial`, `schedule_failure` (scheduler). `dry_run` (#180) marks a `runMainCron({ dryRun: true })` invocation — the full pipeline ran but the Brevo send and `mlb_sent_notifications` insert were skipped; treat such rows as diagnostic, not real sends. Per postmortem #103 / #104, every `*/15` tick now writes exactly one row — silence is treated as a failure mode, so an empty `mlb_cron_runs` hour means the cron itself isn't running and should page, not "no game in window."
 
 ## Break-glass recovery (#110)
 
 When you need to manually kick the cron — e.g. the daily scheduler missed a tick, or a *every-15-min run silently early-returned during a deploy window — the primary recovery path is the **/admin** page, not curl + bearer token.
 
-Three buttons on `/admin`:
+Buttons on `/admin`:
 
 - **Run daily scheduler now** — invokes the same code path as `GET /api/cron/schedule` (populates `mlb_cron_schedule` for today).
 - **Run main cron now** — invokes the same code path as `GET /api/cron` (checks for completed games and sends emails).
+- **Force run main cron (catch up missed)** — same as above but with `force: true`, bypassing the wake-window gate (#154).
 - **Resend latest recap to me** (#150) — re-renders the admin's most recent recap with the current `buildEmailHtml` and sends it back to `ADMIN_EMAIL` with a `[TEST]` subject prefix. Uses `lib/resend-recap.js`, which prefers the latest `mlb_sent_notifications` row for the admin (excluding the welcome sentinel `game_pk = 0`) and falls back to the most recent `mlb_game_cache` row with a `highlight_url`. Standings are re-fetched the same way `runMainCron` does so template changes that depend on `extractTeamStanding` are exercised. Does **not** write to `mlb_sent_notifications` (so it won't block future real sends or pollute analytics) and respects `EMAILS_PAUSED`.
+- **Dry run main cron** (#180) — invokes `runMainCron({ force: true, dryRun: true })`: every read path runs for real (Supabase, MLB API, highlight extraction, `buildEmailHtml`) but the Brevo send and the `mlb_sent_notifications` insert are skipped. Renders an inline report of would-be emails — game PKs, matched subscribers, subjects, highlight URLs. The `mlb_game_cache` upsert still runs (safe write) and the run logs as status `dry_run`. Safe to click at any time; unaffected by `EMAILS_PAUSED` since nothing is sent. End-to-end coverage lives in `lib/cron-jobs.integration.test.js`.
 
 All run as Next.js Server Actions. Auth is the existing admin session check: the action calls `assertAdmin()` server-side (re-checks `auth.getUser()` and `ADMIN_EMAIL`) before doing any work — `notFound()` on the page hides the buttons but is **not** the security boundary. No `CRON_SECRET` is required, since auth is via the user session, not a bearer token. The shared cron logic lives in `lib/cron-jobs.js` (`runMainCron` and `runScheduler`); both the route handlers and the server actions call into it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,20 @@ npm run preview    # Cloudflare local preview
 npm run deploy     # Deploy to Cloudflare (then bootstrap + smoke test, see below)
 ```
 
+### `npm run deploy` pre-deploy test gate (#180)
+
+`npm run deploy` will not build or ship unless the full test suite passes
+first. This is the `predeploy` script in `package.json` (`vitest run`) — npm
+runs any `pre<script>` hook automatically before the script itself, so a
+failing test exits non-zero and aborts the deploy **before** `opennextjs-cloudflare build` runs. Nothing reaches Cloudflare unless all 15
+test files pass, including `lib/cron-jobs.integration.test.js`, which exercises
+the full `runMainCron` fan-out end-to-end (the class of bug from #172/#178).
+
+This is a local gate; the same `npm test` also runs in CI on every pull
+request (`.github/workflows/test.yml`). Treat the integration test fixture as
+living — when a new incident or edge case surfaces, add a scenario to it so the
+gate widens over time.
+
 ### `npm run deploy` post-deploy checks (#108)
 
 After `opennextjs-cloudflare deploy` succeeds, the script chains

--- a/app/admin/actions.js
+++ b/app/admin/actions.js
@@ -80,6 +80,31 @@ export async function forceRunMainCronAction(_prevState, _formData) {
   };
 }
 
+// Dry run (#180): runs the full main-cron pipeline — schedule read, MLB API,
+// cache, dedup, email render — but skips the Brevo send and the
+// mlb_sent_notifications insert. Safe to click at any time; no email goes out
+// and EMAILS_PAUSED is irrelevant. Returns a dryRunReport of would-be emails.
+export async function dryRunMainCronAction(_prevState, _formData) {
+  const auth = await assertAdmin();
+  if (!auth.ok) {
+    return { ok: false, message: auth.error, ranAt: new Date().toISOString() };
+  }
+
+  const supabase = createAdminClient();
+  const { status, body } = await runMainCron({
+    supabase,
+    force: true,
+    dryRun: true,
+  });
+  return {
+    ok: status < 400,
+    message: body.message || body.error || "ran",
+    errors: body.errors,
+    dryRunReport: body.dryRunReport || [],
+    ranAt: new Date().toISOString(),
+  };
+}
+
 export async function resendLatestRecapAction(_prevState, _formData) {
   const ranAt = new Date().toISOString();
   const auth = await assertAdmin();

--- a/app/admin/actions.test.js
+++ b/app/admin/actions.test.js
@@ -36,7 +36,37 @@ vi.mock("@/lib/mlb", async () => {
 });
 
 // Imported after vi.mock so the mocked deps resolve.
-const { resendLatestRecapAction } = await import("./actions");
+const { resendLatestRecapAction, dryRunMainCronAction } = await import("./actions");
+
+// A Supabase stub shaped for the runMainCron pipeline. With no rows in
+// mlb_user_teams, the run short-circuits on the "no_subscribers" path — enough
+// to exercise dryRunMainCronAction's wiring without a full fixture (the
+// end-to-end fan-out is covered by lib/cron-jobs.integration.test.js).
+function makeCronSupabaseStub() {
+  return {
+    from(table) {
+      if (table === "mlb_cron_runs") {
+        return {
+          insert: () => ({
+            select: () => ({
+              single: async () => ({ data: { id: "run-1" }, error: null }),
+            }),
+          }),
+          update: () => ({
+            eq: async () => ({ error: null }),
+            in: () => ({
+              lt: () => ({ select: async () => ({ data: [], error: null }) }),
+            }),
+          }),
+        };
+      }
+      if (table === "mlb_user_teams") {
+        return { select: () => ({ limit: async () => ({ data: [], error: null }) }) };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  };
+}
 
 // Builds a chainable Supabase query stub. Each call to `.from(table)` returns a
 // fresh query object whose terminal calls (`.maybeSingle()`, `.single()`,
@@ -175,6 +205,29 @@ describe("resendLatestRecapAction", () => {
 
     expect(result.ok).toBe(false);
     expect(result.message).toMatch(/paused/i);
+    expect(hoisted.sendEmailImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("dryRunMainCronAction (#180)", () => {
+  it("rejects a non-admin caller without running the cron", async () => {
+    hoisted.authUser = { id: "other-id", email: "imposter@example.com" };
+
+    const result = await dryRunMainCronAction(null, null);
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toBe("Forbidden");
+    expect(hoisted.sendEmailImpl).not.toHaveBeenCalled();
+  });
+
+  it("runs the dry-run pipeline for an admin and returns a dryRunReport", async () => {
+    hoisted.adminSupabase = makeCronSupabaseStub();
+
+    const result = await dryRunMainCronAction(null, null);
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe("No subscribed teams");
+    expect(result.dryRunReport).toEqual([]);
     expect(hoisted.sendEmailImpl).not.toHaveBeenCalled();
   });
 });

--- a/app/admin/break-glass.js
+++ b/app/admin/break-glass.js
@@ -5,10 +5,12 @@ import {
   runSchedulerAction,
   runMainCronAction,
   forceRunMainCronAction,
+  dryRunMainCronAction,
   resendLatestRecapAction,
 } from "./actions";
 
 const INITIAL = { ok: null, message: null, errors: null, ranAt: null };
+const DRY_RUN_INITIAL = { ...INITIAL, dryRunReport: null };
 
 export default function BreakGlass() {
   return (
@@ -36,6 +38,7 @@ export default function BreakGlass() {
           action={resendLatestRecapAction}
         />
       </div>
+      <DryRunButton />
     </div>
   );
 }
@@ -71,5 +74,107 @@ function BreakGlassButton({ label, action }) {
         </div>
       )}
     </form>
+  );
+}
+
+// Dry run is its own full-width row (#180): it renders a report of would-be
+// emails that needs more horizontal room than the 2-column button grid gives.
+function DryRunButton() {
+  const [state, formAction, isPending] = useActionState(
+    dryRunMainCronAction,
+    DRY_RUN_INITIAL
+  );
+
+  return (
+    <form action={formAction} className="mt-3 flex flex-col gap-2">
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded-md border border-indigo-800 bg-indigo-950/40 px-3 py-2 text-sm font-medium text-indigo-100 hover:bg-indigo-900/50 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isPending
+          ? "Running dry run…"
+          : "Dry run main cron (no emails sent)"}
+      </button>
+      {state.ranAt && (
+        <div
+          className={`rounded-md border px-3 py-2 text-xs ${
+            state.ok
+              ? "border-indigo-900/60 bg-indigo-950/20 text-indigo-200"
+              : "border-red-900/60 bg-red-950/20 text-red-300"
+          }`}
+        >
+          <div className="font-mono">{state.message}</div>
+          {state.errors?.length > 0 && (
+            <ul className="mt-1 space-y-0.5 font-mono">
+              {state.errors.map((e, i) => (
+                <li key={i}>• {e}</li>
+              ))}
+            </ul>
+          )}
+          {state.dryRunReport && (
+            <DryRunReport report={state.dryRunReport} />
+          )}
+        </div>
+      )}
+    </form>
+  );
+}
+
+function DryRunReport({ report }) {
+  if (report.length === 0) {
+    return (
+      <p className="mt-2 text-gray-400">
+        No emails would be sent (no new highlights for any subscriber).
+      </p>
+    );
+  }
+
+  const gameCount = new Set(report.map((r) => r.gamePk)).size;
+
+  return (
+    <div className="mt-3">
+      <p className="mb-2 text-gray-300">
+        {report.length} email{report.length === 1 ? "" : "s"} would be sent
+        across {gameCount} game{gameCount === 1 ? "" : "s"}.
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-left font-mono">
+          <thead className="text-gray-500">
+            <tr>
+              <th className="py-1 pr-3 font-medium">Game</th>
+              <th className="py-1 pr-3 font-medium">Team</th>
+              <th className="py-1 pr-3 font-medium">Recipient</th>
+              <th className="py-1 pr-3 font-medium">Subject</th>
+              <th className="py-1 font-medium">Highlight</th>
+            </tr>
+          </thead>
+          <tbody className="text-gray-300">
+            {report.map((r, i) => (
+              <tr key={i} className="border-t border-gray-800">
+                <td className="py-1 pr-3 tabular-nums">{r.gamePk}</td>
+                <td className="py-1 pr-3">{r.teamName}</td>
+                <td className="py-1 pr-3">{r.email}</td>
+                <td className="py-1 pr-3">{r.subject}</td>
+                <td className="py-1">
+                  {r.highlightUrl ? (
+                    <a
+                      href={r.highlightUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-indigo-300 underline"
+                    >
+                      link
+                    </a>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 }

--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -14,6 +14,7 @@ const STATUS_COLORS = {
   no_subscribers: "text-gray-500",
   no_new_highlights: "text-gray-500",
   skipped_no_wake: "text-gray-500",
+  dry_run: "text-indigo-400",
   schedule_running: "text-blue-400",
   schedule_built: "text-green-400",
   schedule_partial: "text-yellow-400",

--- a/lib/cron-jobs.integration.test.js
+++ b/lib/cron-jobs.integration.test.js
@@ -1,0 +1,436 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// End-to-end dry-run coverage for runMainCron (#180).
+//
+// Unlike lib/cron-jobs.test.js, this suite mocks ONLY the network boundary —
+// the MLB Stats API fetches and the Brevo send. Everything in between runs for
+// real: extractFinalGames, extractHighlightUrl, extractSeriesContext,
+// extractTeamStanding and buildEmailHtml. That exercises the full fan-out loop
+// against a realistic multi-game / multi-subscriber fixture, catching the class
+// of bug from #172/#178 that function-level mocks would miss.
+
+const fetchDailySchedule = vi.fn();
+const fetchGameContent = vi.fn();
+const fetchStandings = vi.fn();
+const getDatesToCheck = vi.fn();
+
+vi.mock("@/lib/mlb", async () => {
+  const actual = await vi.importActual("@/lib/mlb");
+  return {
+    ...actual,
+    fetchDailySchedule: (...args) => fetchDailySchedule(...args),
+    fetchGameContent: (...args) => fetchGameContent(...args),
+    fetchStandings: (...args) => fetchStandings(...args),
+    getDatesToCheck: () => getDatesToCheck(),
+  };
+});
+
+// Brevo is the one side effect we stub. In dry-run mode runMainCron must never
+// call it — the test asserts that. buildEmailHtml is intentionally NOT mocked.
+const sendEmail = vi.fn();
+vi.mock("@/lib/brevo", () => ({
+  sendEmail: (...args) => sendEmail(...args),
+}));
+
+import { runMainCron } from "@/lib/cron-jobs";
+
+const DATE_STR = "2026-05-18";
+
+// Teams: Yankees 147, Red Sox 111, Dodgers 119, Giants 137, Cubs 112, Reds 113,
+// Astros 117, Angels 108.
+const GAME_A = 700001; // Yankees (home) vs Red Sox — both fanbases subscribed
+const GAME_B = 700002; // Dodgers (home) vs Giants — cache row has null URL
+const GAME_C = 700003; // Cubs (home) vs Reds — no highlight available
+const GAME_D = 700004; // Astros vs Angels — nobody subscribed, must be ignored
+
+function finalGame(gamePk, homeId, awayId, seriesGameNumber, gamesInSeries) {
+  return {
+    gamePk,
+    gameDate: `${DATE_STR}T23:05:00Z`,
+    status: { abstractGameState: "Final" },
+    teams: {
+      home: { team: { id: homeId }, isWinner: true },
+      away: { team: { id: awayId }, isWinner: false },
+    },
+    seriesGameNumber,
+    gamesInSeries,
+  };
+}
+
+function dailySchedule() {
+  return {
+    dates: [
+      {
+        date: DATE_STR,
+        games: [
+          finalGame(GAME_A, 147, 111, 2, 3),
+          finalGame(GAME_B, 119, 137, 1, 3),
+          finalGame(GAME_C, 112, 113, 3, 3),
+          finalGame(GAME_D, 117, 108, 1, 3),
+          // An in-progress game — extractFinalGames must drop it.
+          {
+            gamePk: 700005,
+            gameDate: `${DATE_STR}T23:40:00Z`,
+            status: { abstractGameState: "Live" },
+            teams: {
+              home: { team: { id: 147 } },
+              away: { team: { id: 110 } },
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function contentWithHighlight(url) {
+  return {
+    highlights: {
+      highlights: {
+        items: [
+          {
+            keywordsAll: [{ value: "game-recap" }],
+            playbacks: [{ name: "mp4Avc", url }],
+          },
+        ],
+      },
+    },
+  };
+}
+
+const STANDINGS = {
+  records: [
+    {
+      division: { id: 201, name: "American League East" },
+      teamRecords: [
+        {
+          team: { id: 147 },
+          divisionRank: "1",
+          wins: 28,
+          losses: 16,
+          gamesBack: "-",
+          wildCardRank: "-",
+          wildCardGamesBack: "-",
+        },
+        {
+          team: { id: 111 },
+          divisionRank: "4",
+          wins: 21,
+          losses: 23,
+          gamesBack: "7.0",
+          wildCardRank: "3",
+          wildCardGamesBack: "2.5",
+        },
+      ],
+    },
+    {
+      division: { id: 204, name: "National League West" },
+      teamRecords: [
+        {
+          team: { id: 119 },
+          divisionRank: "2",
+          wins: 26,
+          losses: 18,
+          gamesBack: "1.5",
+          wildCardRank: "1",
+          wildCardGamesBack: "+1.0",
+        },
+      ],
+    },
+  ],
+};
+
+// Realistic multi-subscriber fixture. user-5 has no email; user-4 already
+// received Game A; user-3 follows two teams.
+const SUBSCRIBED_TEAMS = [
+  { user_id: "user-1", team_id: 147 },
+  { user_id: "user-2", team_id: 111 },
+  { user_id: "user-3", team_id: 147 },
+  { user_id: "user-3", team_id: 119 },
+  { user_id: "user-4", team_id: 147 },
+  { user_id: "user-5", team_id: 111 },
+  { user_id: "user-6", team_id: 112 },
+];
+
+const USERS = [
+  { id: "user-1", email: "yankees-fan@example.com" },
+  { id: "user-2", email: "redsox-fan@example.com" },
+  { id: "user-3", email: "dual-fan@example.com" },
+  { id: "user-4", email: "repeat-fan@example.com" },
+  { id: "user-5", email: null },
+  { id: "user-6", email: "cubs-fan@example.com" },
+];
+
+// Builds a Supabase stub rich enough for the whole runMainCron pipeline and
+// records every write so the test can assert side effects were/weren't taken.
+function makeSupabaseMock() {
+  const writes = {
+    cronRunInserts: [],
+    cronRunUpdates: [],
+    cacheUpserts: [],
+    sentInserts: [],
+  };
+
+  const client = {
+    from(table) {
+      switch (table) {
+        case "mlb_cron_runs":
+          return {
+            insert(row) {
+              writes.cronRunInserts.push(row);
+              return {
+                select: () => ({
+                  single: async () => ({ data: { id: "run-1" }, error: null }),
+                }),
+              };
+            },
+            update(patch) {
+              writes.cronRunUpdates.push(patch);
+              return {
+                eq: async () => ({ error: null }),
+                in: () => ({
+                  lt: () => ({
+                    select: async () => ({ data: [], error: null }),
+                  }),
+                }),
+              };
+            },
+          };
+        case "mlb_user_teams":
+          return {
+            select: () => ({
+              limit: async () => ({ data: SUBSCRIBED_TEAMS, error: null }),
+            }),
+          };
+        case "mlb_game_cache":
+          return {
+            select: () => ({
+              in: async () => ({
+                data: [
+                  { game_pk: GAME_A, highlight_url: "https://mlb.com/video/yankees-recap" },
+                  { game_pk: GAME_B, highlight_url: null },
+                ],
+                error: null,
+              }),
+            }),
+            upsert: async (row) => {
+              writes.cacheUpserts.push(row);
+              return { error: null };
+            },
+          };
+        case "mlb_users":
+          return {
+            select: () => ({
+              in: async () => ({ data: USERS, error: null }),
+            }),
+          };
+        case "mlb_sent_notifications":
+          return {
+            select: () => ({
+              in: () => ({
+                in: async () => ({
+                  data: [{ user_id: "user-4", game_pk: GAME_A }],
+                  error: null,
+                }),
+              }),
+            }),
+            insert: async (row) => {
+              writes.sentInserts.push(row);
+              return { error: null };
+            },
+          };
+        default:
+          throw new Error(`Unexpected table: ${table}`);
+      }
+    },
+  };
+
+  return { client, writes };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getDatesToCheck.mockReturnValue([DATE_STR]);
+  fetchDailySchedule.mockResolvedValue(dailySchedule());
+  fetchStandings.mockResolvedValue(STANDINGS);
+  fetchGameContent.mockImplementation(async (gamePk) => {
+    if (gamePk === GAME_B) return contentWithHighlight("https://mlb.com/video/dodgers-recap");
+    if (gamePk === GAME_C) return {}; // no highlight available
+    throw new Error(`fetchGameContent called unexpectedly for ${gamePk}`);
+  });
+  sendEmail.mockResolvedValue({ ok: true });
+});
+
+describe("runMainCron — end-to-end dry run, multi-game multi-subscriber (#180)", () => {
+  it("produces the correct dryRunReport across the full fan-out", async () => {
+    const { client } = makeSupabaseMock();
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    expect(result.status).toBe(200);
+    expect(result.body.message).toMatch(/^DRY RUN/);
+
+    const report = result.body.dryRunReport;
+    // Game A → Yankees: user-1, user-3 (user-4 deduped). Game A → Red Sox:
+    // user-2 (user-5 has no email). Game B → Dodgers: user-3. = 4 emails.
+    expect(report).toHaveLength(4);
+
+    const recipients = report.map((r) => r.email).sort();
+    expect(recipients).toEqual([
+      "dual-fan@example.com", // Game A, Yankees
+      "dual-fan@example.com", // Game B, Dodgers
+      "redsox-fan@example.com", // Game A, Red Sox
+      "yankees-fan@example.com", // Game A, Yankees
+    ]);
+  });
+
+  it("dedupes a subscriber who already received the game", async () => {
+    const { client } = makeSupabaseMock();
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    const repeatEntries = result.body.dryRunReport.filter(
+      (r) => r.userId === "user-4"
+    );
+    expect(repeatEntries).toHaveLength(0);
+  });
+
+  it("skips a subscriber with no email and never reports the no-subscriber game", async () => {
+    const { client } = makeSupabaseMock();
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+    const report = result.body.dryRunReport;
+
+    // user-5 (no email) must not appear.
+    expect(report.some((r) => r.userId === "user-5")).toBe(false);
+    // Game D (Astros/Angels) has no subscribers — never processed.
+    expect(report.some((r) => r.gamePk === GAME_D)).toBe(false);
+    // Game C (Cubs) has no highlight — never emailed.
+    expect(report.some((r) => r.gamePk === GAME_C)).toBe(false);
+  });
+
+  it("renders real subjects for each rooting team", async () => {
+    const { client } = makeSupabaseMock();
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+    const byTeam = new Map(result.body.dryRunReport.map((r) => [r.teamId, r.subject]));
+
+    expect(byTeam.get(147)).toMatch(/^New York Yankees Highlights/);
+    expect(byTeam.get(111)).toMatch(/^Boston Red Sox Highlights/);
+    expect(byTeam.get(119)).toMatch(/^Los Angeles Dodgers Highlights/);
+  });
+
+  it("carries the correct highlight URL — cached for Game A, freshly fetched for Game B", async () => {
+    const { client } = makeSupabaseMock();
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+    const report = result.body.dryRunReport;
+
+    for (const entry of report.filter((r) => r.gamePk === GAME_A)) {
+      expect(entry.highlightUrl).toBe("https://mlb.com/video/yankees-recap");
+    }
+    for (const entry of report.filter((r) => r.gamePk === GAME_B)) {
+      expect(entry.highlightUrl).toBe("https://mlb.com/video/dodgers-recap");
+    }
+    // Game A's highlight came from cache — its content endpoint is untouched.
+    expect(fetchGameContent).not.toHaveBeenCalledWith(GAME_A);
+    expect(fetchGameContent).toHaveBeenCalledWith(GAME_B);
+    expect(fetchGameContent).toHaveBeenCalledWith(GAME_C);
+  });
+
+  it("attaches spoiler-safe series context from each team's perspective", async () => {
+    const { client } = makeSupabaseMock();
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+    const report = result.body.dryRunReport;
+
+    const yankees = report.find((r) => r.gamePk === GAME_A && r.teamId === 147);
+    expect(yankees.seriesContext).toMatchObject({
+      opponentName: "Red Sox",
+      isHome: true,
+      seriesGameNumber: 2,
+      gamesInSeries: 3,
+    });
+
+    const redsox = report.find((r) => r.gamePk === GAME_A && r.teamId === 111);
+    expect(redsox.seriesContext).toMatchObject({
+      opponentName: "Yankees",
+      isHome: false,
+      seriesGameNumber: 2,
+      gamesInSeries: 3,
+    });
+
+    const dodgers = report.find((r) => r.gamePk === GAME_B);
+    expect(dodgers.seriesContext).toMatchObject({
+      opponentName: "Giants",
+      isHome: true,
+      seriesGameNumber: 1,
+    });
+  });
+
+  it("attaches the spoiler-safe standings snapshot", async () => {
+    const { client } = makeSupabaseMock();
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+    const report = result.body.dryRunReport;
+
+    // Standings are queried for the day BEFORE the game date.
+    expect(fetchStandings).toHaveBeenCalledWith("2026-05-17");
+
+    const yankees = report.find((r) => r.gamePk === GAME_A && r.teamId === 147);
+    expect(yankees.standing).toMatchObject({
+      divisionName: "AL East",
+      divisionRank: 1,
+      wins: 28,
+      losses: 16,
+    });
+  });
+
+  it("performs no irreversible side effects — no send, no dedup insert", async () => {
+    const { client, writes } = makeSupabaseMock();
+
+    await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(writes.sentInserts).toHaveLength(0);
+  });
+
+  it("still upserts mlb_game_cache for games it had to fetch", async () => {
+    const { client, writes } = makeSupabaseMock();
+
+    await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    // Game B (null cache) and Game C (uncached) get re-checked and upserted;
+    // Game A was already cached so it is not re-written.
+    const upsertedPks = writes.cacheUpserts.map((r) => r.game_pk).sort();
+    expect(upsertedPks).toEqual([GAME_B, GAME_C]);
+  });
+
+  it("finalizes the run with the distinct dry_run status", async () => {
+    const { client, writes } = makeSupabaseMock();
+
+    await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    const finalize = writes.cronRunUpdates.find((u) => u.status === "dry_run");
+    expect(finalize).toBeDefined();
+    expect(finalize).toMatchObject({
+      status: "dry_run",
+      games_processed: 3,
+      emails_sent: 4,
+    });
+    expect(writes.cronRunUpdates.some((u) => u.status === "success")).toBe(false);
+  });
+
+  it("sends real emails and writes dedup rows when dryRun is off", async () => {
+    const { client, writes } = makeSupabaseMock();
+
+    const result = await runMainCron({ supabase: client, force: true });
+
+    // Same fan-out, but now the side effects fire.
+    expect(result.body.message).toMatch(/sent 4 emails/);
+    expect(result.body.dryRunReport).toBeUndefined();
+    expect(sendEmail).toHaveBeenCalledTimes(4);
+    expect(writes.sentInserts).toHaveLength(4);
+    expect(writes.cronRunUpdates.some((u) => u.status === "success")).toBe(true);
+  });
+});

--- a/lib/cron-jobs.js
+++ b/lib/cron-jobs.js
@@ -119,9 +119,21 @@ async function finalizeRun(
 // to thread Worker-side values explicitly (#163). HTTP callers omit it and
 // the libs fall back to process.env (which OpenNext's fetch wrapper has
 // populated by then).
+// `dryRun: true` (#180) executes every real read path — Supabase reads, MLB
+// API fetches, highlight extraction, email rendering — but skips the two
+// irreversible side effects: the Brevo send and the mlb_sent_notifications
+// dedup insert. The mlb_game_cache upsert still runs (safe write). The run is
+// finalized with status "dry_run" and the body carries a `dryRunReport` array
+// with one entry per would-be email. Safe to invoke at any time.
 // Returns { status, body } where status is an HTTP status hint and body is the
 // JSON-able payload to render.
-export async function runMainCron({ supabase, env, emailsPaused = false, force = false } = {}) {
+export async function runMainCron({
+  supabase,
+  env,
+  emailsPaused = false,
+  force = false,
+  dryRun = false,
+} = {}) {
   const emailOpts = env
     ? { apiKey: env.EMAIL_API_KEY, fromEmail: env.FROM_EMAIL }
     : undefined;
@@ -180,6 +192,7 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
 
   const runId = await startRun(supabase, "running");
   const errors = [];
+  const dryRunReport = [];
 
   try {
     const dates = getDatesToCheck();
@@ -202,7 +215,10 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
 
     if (teamIds.length === 0) {
       await finalizeRun(supabase, runId, "no_subscribers", { errors });
-      return { status: 200, body: { message: "No subscribed teams" } };
+      return {
+        status: 200,
+        body: { message: "No subscribed teams", ...(dryRun ? { dryRunReport } : {}) },
+      };
     }
 
     console.log(`Checking ${teamIds.length} teams across dates: ${dates.join(", ")}`);
@@ -297,14 +313,15 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
     }
 
     if (newGames.length === 0) {
-      await finalizeRun(supabase, runId, errors.length > 0 ? "partial" : "no_new_highlights", {
-        errors,
-      });
+      const noGamesStatus =
+        errors.length > 0 ? (dryRun ? "dry_run" : "partial") : "no_new_highlights";
+      await finalizeRun(supabase, runId, noGamesStatus, { errors });
       return {
         status: 200,
         body: {
           message: "No new highlights available",
           errors: errors.length > 0 ? errors : undefined,
+          ...(dryRun ? { dryRunReport } : {}),
         },
       };
     }
@@ -418,6 +435,27 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
           { ...(templateOpts || {}), seriesContext }
         );
 
+        if (dryRun) {
+          // Skip the two irreversible side effects — the Brevo send and the
+          // mlb_sent_notifications dedup insert (#180). Everything above
+          // (reads, cache upsert, render) already ran for real.
+          console.log(`DRY RUN: would send to ${email} — "${subject}"`);
+          dryRunReport.push({
+            gamePk: game.gamePk,
+            gameDate: game.gameDate,
+            teamId: game.teamId,
+            teamName,
+            userId,
+            email,
+            subject,
+            highlightUrl: game.highlightUrl,
+            standing,
+            seriesContext,
+          });
+          emailsSent++;
+          continue;
+        }
+
         try {
           await sendEmail(email, subject, html, emailOpts);
 
@@ -435,7 +473,12 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
       }
     }
 
-    await finalizeRun(supabase, runId, errors.length > 0 ? "partial" : "success", {
+    const finalStatus = dryRun
+      ? "dry_run"
+      : errors.length > 0
+        ? "partial"
+        : "success";
+    await finalizeRun(supabase, runId, finalStatus, {
       gamesProcessed: newGames.length,
       emailsSent,
       errors,
@@ -444,9 +487,12 @@ export async function runMainCron({ supabase, env, emailsPaused = false, force =
     return {
       status: 200,
       body: {
-        message: `Processed ${newGames.length} games, sent ${emailsSent} emails`,
+        message: dryRun
+          ? `DRY RUN: ${newGames.length} games processed, ${emailsSent} emails would be sent`
+          : `Processed ${newGames.length} games, sent ${emailsSent} emails`,
         errors: errors.length > 0 ? errors : undefined,
         skipped: skipped.length > 0 ? skipped : undefined,
+        ...(dryRun ? { dryRunReport } : {}),
       },
     };
   } catch (err) {

--- a/lib/cron-jobs.staging.test.js
+++ b/lib/cron-jobs.staging.test.js
@@ -1,0 +1,99 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { createStagingClient } from "@/lib/supabase-admin";
+
+// Automated end-to-end dry-run against a real STAGING Supabase project (#180).
+//
+// Unlike lib/cron-jobs.integration.test.js (deterministic, fully mocked at the
+// network boundary), this suite runs runMainCron against:
+//   * a real staging Supabase project — real PostgREST queries, real
+//     RLS-bypass via the service role, real mlb_game_cache upserts; and
+//   * the live MLB Stats API.
+// Only the Brevo send is stubbed — and stubbed to THROW, so a regression that
+// tried to send during a dry run fails loudly instead of mailing anyone.
+//
+// It is a live smoke test. Report contents depend on MLB's actual slate, so it
+// asserts the pipeline completes end-to-end and finalizes with the dry_run
+// status — not a specific set of emails. That catches the class of bug only a
+// real database surfaces: query-shape errors, client misconfiguration,
+// PostgREST incompatibilities — which module-level mocks cannot.
+//
+// It is EXCLUDED from the default `npm test` / predeploy gate (see the
+// `exclude` glob in vitest.config.mjs) and runs only via `npm run test:staging`
+// (vitest.staging.config.mjs), so live MLB API flakiness can never block a
+// deploy. When the SUPABASE_STAGING_* env vars are unset the suite skips
+// cleanly — green on forks and before staging is provisioned.
+
+const stagingConfigured =
+  !!process.env.SUPABASE_STAGING_URL &&
+  !!process.env.SUPABASE_STAGING_SERVICE_ROLE_KEY;
+
+// Stub Brevo to throw — a dry run must never reach it. Defined before vi.mock
+// so the hoisted factory closes over an initialized reference.
+const sendEmail = vi.fn(() => {
+  throw new Error("staging dry run attempted a real Brevo send");
+});
+vi.mock("@/lib/brevo", () => ({
+  sendEmail: (...args) => sendEmail(...args),
+}));
+
+describe.skipIf(!stagingConfigured)(
+  "runMainCron — automated dry run against staging Supabase (#180)",
+  () => {
+    let runMainCron;
+    let staging;
+
+    beforeAll(async () => {
+      ({ runMainCron } = await import("@/lib/cron-jobs"));
+      staging = createStagingClient();
+    });
+
+    it(
+      "runs the full pipeline end-to-end and finalizes with dry_run",
+      async () => {
+        const result = await runMainCron({
+          supabase: staging,
+          force: true,
+          dryRun: true,
+        });
+
+        // The pipeline completed without throwing.
+        expect(result.status).toBe(200);
+        // No Brevo call was even attempted.
+        expect(sendEmail).not.toHaveBeenCalled();
+        // dryRun always returns a report array (possibly empty in the offseason
+        // or on a day with no completed games for the fixture teams).
+        expect(Array.isArray(result.body.dryRunReport)).toBe(true);
+
+        // Every report entry carries the fields the /admin view and the
+        // operator depend on.
+        for (const entry of result.body.dryRunReport) {
+          expect(entry).toMatchObject({
+            gamePk: expect.any(Number),
+            teamId: expect.any(Number),
+            email: expect.any(String),
+            subject: expect.any(String),
+          });
+        }
+
+        // The run wrote a dry_run row to the staging health log.
+        const { data: latestRun, error } = await staging
+          .from("mlb_cron_runs")
+          .select("status")
+          .order("started_at", { ascending: false })
+          .limit(1)
+          .single();
+        expect(error).toBeNull();
+        expect(latestRun.status).toBe("dry_run");
+      },
+      180000
+    );
+  }
+);
+
+// Visibility net: if someone runs `npm run test:staging` without configuring
+// the project, surface why nothing meaningful ran instead of a silent green.
+describe.runIf(!stagingConfigured)("staging dry run (not configured)", () => {
+  it("skips because SUPABASE_STAGING_* env vars are unset", () => {
+    expect(stagingConfigured).toBe(false);
+  });
+});

--- a/lib/cron-jobs.test.js
+++ b/lib/cron-jobs.test.js
@@ -76,23 +76,33 @@ function makeContentWithHighlight(url = HIGHLIGHT_URL) {
 //   null       → row exists with highlight_url = null (checked, no highlight yet)
 //   string     → row exists with a real URL (highlight already found)
 function makeSupabaseMock({ cachedHighlightUrl = undefined } = {}) {
+  const sentInsert = vi.fn(async () => ({ error: null }));
+  const cacheUpsert = vi.fn(async () => ({ error: null }));
+  const cronRunInsert = vi.fn();
+  const cronRunUpdate = vi.fn();
   const client = {
     from: vi.fn((table) => {
       if (table === "mlb_cron_runs") {
         return {
-          insert: () => ({
-            select: () => ({
-              single: async () => ({ data: { id: "run-1" }, error: null }),
-            }),
-          }),
-          update: () => ({
-            eq: async () => ({ error: null }),
-            in: () => ({
-              lt: () => ({
-                select: async () => ({ data: [], error: null }),
+          insert: (row) => {
+            cronRunInsert(row);
+            return {
+              select: () => ({
+                single: async () => ({ data: { id: "run-1" }, error: null }),
               }),
-            }),
-          }),
+            };
+          },
+          update: (patch) => {
+            cronRunUpdate(patch);
+            return {
+              eq: async () => ({ error: null }),
+              in: () => ({
+                lt: () => ({
+                  select: async () => ({ data: [], error: null }),
+                }),
+              }),
+            };
+          },
         };
       }
       if (table === "mlb_user_teams") {
@@ -116,7 +126,7 @@ function makeSupabaseMock({ cachedHighlightUrl = undefined } = {}) {
               error: null,
             }),
           }),
-          upsert: async () => ({ error: null }),
+          upsert: cacheUpsert,
         };
       }
       if (table === "mlb_users") {
@@ -136,13 +146,13 @@ function makeSupabaseMock({ cachedHighlightUrl = undefined } = {}) {
               in: async () => ({ data: [], error: null }),
             }),
           }),
-          insert: async () => ({ error: null }),
+          insert: sentInsert,
         };
       }
       throw new Error(`Unexpected table: ${table}`);
     }),
   };
-  return { client };
+  return { client, sentInsert, cacheUpsert, cronRunInsert, cronRunUpdate };
 }
 
 beforeEach(() => {
@@ -190,5 +200,96 @@ describe("runMainCron — null highlight_url cache regression (#178)", () => {
     expect(fetchGameContent).toHaveBeenCalledWith(GAME_PK);
     expect(sendEmail).not.toHaveBeenCalled();
     expect(result.body.message).toBe("No new highlights available");
+  });
+});
+
+describe("runMainCron — dry-run mode (#180)", () => {
+  it("skips the Brevo send and the mlb_sent_notifications insert", async () => {
+    const { client, sentInsert } = makeSupabaseMock({ cachedHighlightUrl: HIGHLIGHT_URL });
+    fetchDailySchedule.mockResolvedValue(makeDailySchedule());
+
+    await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(sentInsert).not.toHaveBeenCalled();
+  });
+
+  it("still upserts mlb_game_cache so cache logic is exercised", async () => {
+    // Cache row exists but highlight_url is null → the game is re-fetched and
+    // the cache upsert must still run in dry-run mode.
+    const { client, cacheUpsert } = makeSupabaseMock({ cachedHighlightUrl: null });
+    fetchDailySchedule.mockResolvedValue(makeDailySchedule());
+    fetchGameContent.mockResolvedValue(makeContentWithHighlight());
+
+    await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    expect(fetchGameContent).toHaveBeenCalledWith(GAME_PK);
+    expect(cacheUpsert).toHaveBeenCalledTimes(1);
+    expect(cacheUpsert.mock.calls[0][0]).toMatchObject({
+      game_pk: GAME_PK,
+      highlight_url: HIGHLIGHT_URL,
+    });
+  });
+
+  it("finalizes the run with status dry_run instead of success", async () => {
+    const { client, cronRunUpdate } = makeSupabaseMock({ cachedHighlightUrl: HIGHLIGHT_URL });
+    fetchDailySchedule.mockResolvedValue(makeDailySchedule());
+
+    await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    const finalize = cronRunUpdate.mock.calls
+      .map((c) => c[0])
+      .find((patch) => patch.status === "dry_run");
+    expect(finalize).toBeDefined();
+    expect(finalize).toMatchObject({ status: "dry_run", emails_sent: 1, games_processed: 1 });
+    expect(
+      cronRunUpdate.mock.calls.some((c) => c[0].status === "success")
+    ).toBe(false);
+  });
+
+  it("returns a dryRunReport with one entry per would-be email", async () => {
+    const { client } = makeSupabaseMock({ cachedHighlightUrl: HIGHLIGHT_URL });
+    fetchDailySchedule.mockResolvedValue(makeDailySchedule());
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    expect(result.body.message).toMatch(/DRY RUN/);
+    expect(result.body.dryRunReport).toHaveLength(1);
+    expect(result.body.dryRunReport[0]).toMatchObject({
+      gamePk: GAME_PK,
+      teamId: TEAM_ID,
+      userId: USER_ID,
+      email: USER_EMAIL,
+      highlightUrl: HIGHLIGHT_URL,
+    });
+    expect(result.body.dryRunReport[0].subject).toEqual(expect.any(String));
+  });
+
+  it("includes an empty dryRunReport when there are no subscribers", async () => {
+    const { client } = makeSupabaseMock({ cachedHighlightUrl: HIGHLIGHT_URL });
+    // Override mlb_user_teams to return no rows.
+    const baseFrom = client.from;
+    client.from = vi.fn((table) => {
+      if (table === "mlb_user_teams") {
+        return { select: () => ({ limit: async () => ({ data: [], error: null }) }) };
+      }
+      return baseFrom(table);
+    });
+    fetchDailySchedule.mockResolvedValue(makeDailySchedule());
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    expect(result.body.message).toBe("No subscribed teams");
+    expect(result.body.dryRunReport).toEqual([]);
+  });
+
+  it("does not write a dryRunReport on a normal (non-dry) run", async () => {
+    const { client } = makeSupabaseMock({ cachedHighlightUrl: HIGHLIGHT_URL });
+    fetchDailySchedule.mockResolvedValue(makeDailySchedule());
+
+    const result = await runMainCron({ supabase: client, force: true });
+
+    expect(result.body.dryRunReport).toBeUndefined();
+    expect(sendEmail).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/supabase-admin.js
+++ b/lib/supabase-admin.js
@@ -13,3 +13,17 @@ export function createAdminClient(supabaseUrl, serviceRoleKey) {
     serviceRoleKey ?? process.env.SUPABASE_SERVICE_ROLE_KEY
   );
 }
+
+// Service-role client for the STAGING Supabase project (#180). The automated
+// dry-run (lib/cron-jobs.staging.test.js) uses this so its mlb_game_cache and
+// mlb_cron_runs writes land in an isolated project, never production.
+//
+// Returns null when SUPABASE_STAGING_URL / SUPABASE_STAGING_SERVICE_ROLE_KEY
+// are unset, so callers can skip cleanly rather than crash — staging is opt-in
+// infrastructure and these values are never present in production.
+export function createStagingClient() {
+  const url = process.env.SUPABASE_STAGING_URL;
+  const key = process.env.SUPABASE_STAGING_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createClient(url, key);
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:staging": "vitest run --config vitest.staging.config.mjs",
     "predeploy": "vitest run",
     "preview": "opennextjs-cloudflare build && node scripts/inject-scheduled.mjs && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && node scripts/inject-scheduled.mjs && opennextjs-cloudflare deploy && node scripts/post-deploy-check.mjs"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "test": "vitest run",
     "test:watch": "vitest",
+    "predeploy": "vitest run",
     "preview": "opennextjs-cloudflare build && node scripts/inject-scheduled.mjs && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && node scripts/inject-scheduled.mjs && opennextjs-cloudflare deploy && node scripts/post-deploy-check.mjs"
   },

--- a/supabase/staging-seed.sql
+++ b/supabase/staging-seed.sql
@@ -1,0 +1,66 @@
+-- Staging fixture seed for the automated cron dry-run (#180).
+--
+-- Apply this ONCE to the STAGING Supabase project, AFTER supabase-schema.sql.
+-- Never run it against production.
+--
+-- It seeds two fixture subscribers so the automated dry-run
+-- (`npm run test:staging` / lib/cron-jobs.staging.test.js) always has real
+-- rows to fan out against:
+--
+--   * a "superfan" subscribed to all 30 MLB teams, so whichever games MLB
+--     actually played in the last few days, the fan-out path is exercised;
+--   * a second subscriber on two teams, for multi-subscriber realism.
+--
+-- The dry-run never sends email and never writes mlb_sent_notifications, so
+-- these fixture accounts stay inert. Their addresses use the RFC 2606
+-- example.com domain, which has no MX record — even an accidental real send
+-- could not deliver. The seed is idempotent: re-running it is a no-op.
+--
+-- mlb_user_teams.user_id has a foreign key to auth.users, so the fixture
+-- accounts must exist there first. The inserts below use the standard
+-- direct-insert form. If your Supabase version rejects writes to auth.users,
+-- create two users via the dashboard (Authentication -> Add user) instead and
+-- replace the UUIDs below with the ones it assigns.
+
+insert into auth.users (
+  instance_id, id, aud, role, email,
+  encrypted_password, email_confirmed_at,
+  created_at, updated_at,
+  raw_app_meta_data, raw_user_meta_data
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '00000000-0000-0000-0000-0000000d0001',
+    'authenticated', 'authenticated',
+    'staging-dry-run-superfan@example.com',
+    '', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}', '{}'
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '00000000-0000-0000-0000-0000000d0002',
+    'authenticated', 'authenticated',
+    'staging-dry-run-fan-b@example.com',
+    '', now(), now(), now(),
+    '{"provider":"email","providers":["email"]}', '{}'
+  )
+on conflict (id) do nothing;
+
+-- Superfan: every MLB team, so any recent real game matches a subscription.
+insert into public.mlb_user_teams (user_id, team_id)
+select '00000000-0000-0000-0000-0000000d0001', team_id
+from unnest(array[
+  108, 109, 110, 111, 112, 113, 114, 115, 116, 117,
+  118, 119, 120, 121, 133, 134, 135, 136, 137, 138,
+  139, 140, 141, 142, 143, 144, 145, 146, 147, 158
+]) as team_id
+on conflict (user_id, team_id) do nothing;
+
+-- Fan B: Yankees (147) and Dodgers (119) — exercises multi-subscriber fan-out
+-- and the both-fanbases-subscribed case when these two meet.
+insert into public.mlb_user_teams (user_id, team_id)
+values
+  ('00000000-0000-0000-0000-0000000d0002', 147),
+  ('00000000-0000-0000-0000-0000000d0002', 119)
+on conflict (user_id, team_id) do nothing;

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -10,6 +10,14 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["**/*.test.{js,mjs}"],
-    exclude: ["node_modules/**", ".next/**", ".open-next/**"],
+    // *.staging.test.* runs only via `npm run test:staging`
+    // (vitest.staging.config.mjs) — it makes live network calls and must not
+    // gate the deterministic `npm test` / predeploy run. See #180.
+    exclude: [
+      "node_modules/**",
+      ".next/**",
+      ".open-next/**",
+      "**/*.staging.test.{js,mjs}",
+    ],
   },
 });

--- a/vitest.staging.config.mjs
+++ b/vitest.staging.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+// Config for the staging dry-run smoke test only (#180). Run via
+// `npm run test:staging`. The default config (vitest.config.mjs) deliberately
+// EXCLUDES *.staging.test.* so live MLB API / staging-Supabase flakiness can
+// never block the deterministic `npm test` / predeploy gate.
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL(".", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["**/*.staging.test.{js,mjs}"],
+    exclude: ["node_modules/**", ".next/**", ".open-next/**"],
+  },
+});


### PR DESCRIPTION
## Summary

Implements issue #180 — an end-to-end dry-run testing environment for the cron pipeline, so the class of regression from #172/#178 (refactors that passed unit tests but broke the real fan-out) is caught before reaching production.

- **`dryRun` flag in `runMainCron`** — executes every real read path (Supabase, MLB API, highlight extraction, `buildEmailHtml`) but skips the two irreversible side effects: the Brevo send and the `mlb_sent_notifications` dedup insert. The `mlb_game_cache` upsert still runs. The run finalizes with the distinct status `dry_run` and the response body carries a `dryRunReport` array — one entry per would-be email (game PK, subscriber, subject, highlight URL, plus resolved standings/series context). Defaults to `false`, so production paths are unchanged.
- **`/admin` "Dry run main cron" button** — a break-glass button that runs `runMainCron({ force: true, dryRun: true })` and renders the would-be-email report inline. No Brevo calls; safe to click at any time.
- **Deterministic integration test** (`lib/cron-jobs.integration.test.js`) — exercises the full fan-out against a realistic multi-game / multi-subscriber fixture with only the network boundary mocked. Real `buildEmailHtml` and `extract*` functions run. Covers dedup, no-email subscribers, null-cache re-fetch, no-highlight games, and unsubscribed games.
- **Pre-deploy test gate** — a `predeploy` npm lifecycle script makes `npm run deploy` abort before building/shipping if any test fails. The integration test is now a hard pre-production gate, not just a CI check on PRs.
- **Automated staging dry-run** (stretch item #4) — `createStagingClient()`, a fixture seed (`supabase/staging-seed.sql`), and `lib/cron-jobs.staging.test.js` run the pipeline against an isolated staging Supabase project + the live MLB API (Brevo stubbed to throw). Excluded from the default `npm test` so live-API flakiness can't block a deploy; runs via `npm run test:staging` and `.github/workflows/dry-run-staging.yml`. Self-skips cleanly when `SUPABASE_STAGING_*` env vars are unset.

`mlb_cron_runs.status` has no CHECK constraint, so the new `dry_run` status needs no migration. `CLAUDE.md` is updated to document all of the above.

## Activating the staging layer (one-time, owner action)

The staging code is fully wired but inert until you:
1. Create a free-tier Supabase project (separate from production).
2. Run `supabase-schema.sql` then `supabase/staging-seed.sql` against it.
3. Add `SUPABASE_STAGING_URL` and `SUPABASE_STAGING_SERVICE_ROLE_KEY` as GitHub Actions secrets.

Recommend keeping `dry-run-staging` an informational (non-required) check until staging is proven stable — the deterministic `test` job stays the hard merge gate.

## Test plan

- [x] `npm test` — 158 tests across 15 files pass (139 original + 19 new); staging test correctly excluded
- [x] `npm run test:staging` — self-skips cleanly with no staging env configured
- [x] `npm run build` — production build succeeds
- [x] `predeploy` hook verified to run the suite before `deploy`
- [ ] After merge: provision the staging Supabase project and confirm `dry-run-staging` goes green
- [ ] Click the `/admin` "Dry run main cron" button in production and confirm the report renders with no emails sent

https://claude.ai/code/session_01VCNKzvU6HyRJBnrnBE6cdm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCNKzvU6HyRJBnrnBE6cdm)_