### PR TITLE
Add self-serve account deletion (GDPR) — closes #24

### DIFF
--- a/app/api/account/route.js
+++ b/app/api/account/route.js
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase-server";
+import { createAdminClient } from "@/lib/supabase-admin";
+import { deleteAccount } from "@/lib/delete-account";
+
+export async function DELETE() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+
+  try {
+    const result = await deleteAccount({
+      admin,
+      userId: user.id,
+      email: user.email,
+    });
+    // The auth.users row is gone, so the session is already dead server-side.
+    // signOut clears the now-orphaned auth cookies so the browser doesn't keep
+    // presenting a stale session after the redirect.
+    await supabase.auth.signOut();
+    return NextResponse.json(result);
+  } catch (err) {
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/app/dashboard/delete-account.js
+++ b/app/dashboard/delete-account.js
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+
+export default function DeleteAccount() {
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const canDelete = confirmText === "DELETE" && !deleting;
+
+  function cancel() {
+    setOpen(false);
+    setConfirmText("");
+    setError(null);
+  }
+
+  async function handleDelete() {
+    if (!canDelete) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/account", { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Deletion failed. Please try again.");
+      }
+      // Full navigation, not router.push: drops any cached client state and
+      // forces a fresh request now that the session cookie has been cleared.
+      window.location.href = "/";
+    } catch (err) {
+      setError(err.message);
+      setDeleting(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="mt-3 text-sm font-medium text-[#c87d7b] underline-offset-4 transition hover:text-[#e09b99] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b8312f] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1311]"
+      >
+        Delete account
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="alertdialog"
+      aria-labelledby="delete-account-heading"
+      className="mt-4 rounded-2xl border border-[#5c2b2a] bg-[#2a1413]/60 p-5"
+    >
+      <h3
+        id="delete-account-heading"
+        className="text-sm font-semibold text-[#f7f5ef]"
+      >
+        Permanently delete your account?
+      </h3>
+      <p className="mt-2 text-sm text-[#c4a9a8]">
+        This removes your account, every team you follow, and your recap
+        history. It cannot be undone. You&apos;ll get one final email
+        confirming the deletion.
+      </p>
+
+      <label
+        htmlFor="delete-confirm"
+        className="mt-4 block text-xs font-medium text-[#c4a9a8]"
+      >
+        Type <span className="font-bold text-[#f7f5ef]">DELETE</span> to confirm
+      </label>
+      <input
+        id="delete-confirm"
+        type="text"
+        value={confirmText}
+        onChange={(e) => setConfirmText(e.target.value)}
+        autoComplete="off"
+        disabled={deleting}
+        className="mt-1.5 w-full max-w-[220px] rounded-lg border border-[#5c2b2a] bg-[#0f1311] px-3 py-2 text-sm text-[#f7f5ef] focus:border-[#b8312f] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#b8312f]"
+      />
+
+      {error && (
+        <p role="alert" className="mt-3 text-sm text-[#e09b99]">
+          {error}
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={!canDelete}
+          className="inline-flex items-center justify-center rounded-lg bg-[#b8312f] px-4 py-2 text-sm font-semibold text-[#f7f5ef] transition hover:bg-[#cf3a37] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#e09b99] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1311] disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {deleting ? "Deleting…" : "Permanently delete"}
+        </button>
+        <button
+          type="button"
+          onClick={cancel}
+          disabled={deleting}
+          className="text-sm font-medium text-[#a8a299] transition hover:text-[#f7f5ef] disabled:opacity-40"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase-server";
 import { MLB_TEAMS } from "@/lib/teams";
 import TeamGrid from "./team-grid";
 import SignupTracker from "./signup-tracker";
+import DeleteAccount from "./delete-account";
 import { Suspense } from "react";
 import pkg from "../../package.json";
 import { BrandLockup } from "@/components/brand";
@@ -108,6 +109,19 @@ export default async function DashboardPage() {
             )}
 
             <TeamGrid teams={MLB_TEAMS} followedIds={[...followedIds]} />
+
+            <div className="mt-16 border-t border-[#1f3a2c] pt-8">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-[#a8a299]">
+                Account
+              </h2>
+              <p className="mt-2 max-w-prose text-sm text-[#a8a299]">
+                Deleting your account permanently removes your email address,
+                the teams you follow, and your recap history. This can&apos;t be
+                undone — to simply stop emails without losing your account, use
+                the unsubscribe link instead.
+              </p>
+              <DeleteAccount />
+            </div>
           </div>
         </section>
       </main>

--- a/app/privacy/page.js
+++ b/app/privacy/page.js
@@ -112,15 +112,31 @@ export default function PrivacyPage() {
               account in place.
             </p>
             <p className="mt-3">
-              To delete your account and all associated data, email{" "}
+              To delete your account and everything tied to it, open your{" "}
+              <Link
+                href="/dashboard"
+                className="text-[#f7f5ef] underline hover:text-[#b8312f] transition"
+              >
+                dashboard
+              </Link>{" "}
+              and use the <strong className="text-[#f7f5ef]">Delete account</strong>{" "}
+              option under Account. It removes your email address, the teams you
+              follow, and your recap history immediately, and we email you a
+              confirmation. The deletion is permanent and can&apos;t be undone.
+            </p>
+            <p className="mt-3">
+              Deleted data is also purged from our database provider&apos;s
+              automated backups, which are retained for up to 7 days for
+              disaster recovery. After that window passes, no copy of your data
+              remains. If you&apos;d rather not use the dashboard, email{" "}
               <a
                 href="mailto:highlights@ninthinning.email?subject=Delete%20my%20account"
                 className="text-[#f7f5ef] underline hover:text-[#b8312f] transition"
               >
                 highlights@ninthinning.email
               </a>{" "}
-              from the address you signed up with. We'll confirm and delete
-              within 7 days. Self-serve account deletion is on the roadmap.
+              from the address you signed up with and we&apos;ll handle it for
+              you.
             </p>
           </section>
 

--- a/lib/delete-account.js
+++ b/lib/delete-account.js
@@ -1,0 +1,36 @@
+import { buildAccountDeletedEmailHtml } from "@/lib/email-template";
+import { sendEmail } from "@/lib/brevo";
+
+const DELETED_SUBJECT = "Your Ninth Inning Email account was deleted";
+
+// Permanently delete a user account and everything tied to it (#24).
+//
+// mlb_user_teams and mlb_sent_notifications both declare their user_id foreign
+// key as `on delete cascade` against auth.users (see supabase-schema.sql), so
+// removing the auth.users row drops every related mlb_* row in the same
+// database transaction. That cascade is the "single transaction" the deletion
+// needs — it leaves no orphan rows for the cron's next run to trip over, which
+// three separate PostgREST deletes could not guarantee.
+//
+// The confirmation email is best-effort: by the time it sends the account is
+// already gone and the delete is irreversible, so a Brevo failure must not be
+// reported back as a failed deletion.
+export async function deleteAccount({ admin, userId, email, sendImpl = sendEmail }) {
+  const { error } = await admin.auth.admin.deleteUser(userId);
+
+  if (error) {
+    throw new Error(`Failed to delete account: ${error.message}`);
+  }
+
+  let emailSent = false;
+  if (email) {
+    try {
+      await sendImpl(email, DELETED_SUBJECT, buildAccountDeletedEmailHtml());
+      emailSent = true;
+    } catch (err) {
+      console.error("Account deleted but confirmation email failed:", err);
+    }
+  }
+
+  return { deleted: true, emailSent };
+}

--- a/lib/delete-account.test.js
+++ b/lib/delete-account.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { deleteAccount } from "./delete-account";
+
+function makeAdminStub({ deleteError = null } = {}) {
+  const deleteCalls = [];
+  return {
+    auth: {
+      admin: {
+        deleteUser: (id) => {
+          deleteCalls.push(id);
+          return Promise.resolve({ data: {}, error: deleteError });
+        },
+      },
+    },
+    _calls: { deleteCalls },
+  };
+}
+
+describe("deleteAccount", () => {
+  it("deletes the auth user and sends the confirmation email", async () => {
+    const admin = makeAdminStub();
+    const sendImpl = vi.fn(async () => undefined);
+
+    const result = await deleteAccount({
+      admin,
+      userId: "u1",
+      email: "fan@example.com",
+      sendImpl,
+    });
+
+    expect(result).toEqual({ deleted: true, emailSent: true });
+    expect(admin._calls.deleteCalls).toEqual(["u1"]);
+    expect(sendImpl).toHaveBeenCalledTimes(1);
+    const [to, subject, html] = sendImpl.mock.calls[0];
+    expect(to).toBe("fan@example.com");
+    expect(subject).toMatch(/deleted/i);
+    expect(html).toContain("Your account was deleted");
+  });
+
+  it("throws when the admin delete fails and never sends an email", async () => {
+    const admin = makeAdminStub({ deleteError: { message: "user not found" } });
+    const sendImpl = vi.fn();
+
+    await expect(
+      deleteAccount({ admin, userId: "u1", email: "fan@example.com", sendImpl })
+    ).rejects.toThrow(/user not found/);
+
+    expect(sendImpl).not.toHaveBeenCalled();
+  });
+
+  it("still reports success when the confirmation email fails (best-effort)", async () => {
+    const admin = makeAdminStub();
+    const sendImpl = vi.fn(async () => {
+      throw new Error("Brevo 500: boom");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await deleteAccount({
+      admin,
+      userId: "u1",
+      email: "fan@example.com",
+      sendImpl,
+    });
+
+    expect(result).toEqual({ deleted: true, emailSent: false });
+    expect(admin._calls.deleteCalls).toEqual(["u1"]);
+    errorSpy.mockRestore();
+  });
+
+  it("skips the confirmation email when the user has no email", async () => {
+    const admin = makeAdminStub();
+    const sendImpl = vi.fn();
+
+    const result = await deleteAccount({
+      admin,
+      userId: "u1",
+      email: null,
+      sendImpl,
+    });
+
+    expect(result).toEqual({ deleted: true, emailSent: false });
+    expect(sendImpl).not.toHaveBeenCalled();
+  });
+});

--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -164,6 +164,61 @@ export function buildWelcomeEmailHtml(userId, { siteUrl: siteUrlOverride, tipUrl
 </html>`;
 }
 
+// One-time account-deletion confirmation email (#24). Deliberately minimal:
+// no unsubscribe link (the account is gone, there is no userId to encode) and
+// no tip prompt — just a branded confirmation that the deletion happened.
+export function buildAccountDeletedEmailHtml({ siteUrl: siteUrlOverride } = {}) {
+  const siteUrl = getSiteUrl(siteUrlOverride);
+  const accent = BRAND_GREEN;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Your Ninth Inning Email account was deleted</title>
+</head>
+<body style="margin:0;padding:0;background-color:#efece4;font-family:'Hanken Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#efece4;">
+<tr><td align="center" style="padding:24px 16px;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;background-color:${BRAND_PAPER};border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+
+  <!-- Brand accent bar -->
+  <tr><td style="height:6px;background-color:${accent};"></td></tr>
+
+  <!-- Wordmark -->
+  <tr><td style="padding:24px 32px 0 32px;">
+    ${brandWordmarkHtml({ size: 14 })}
+  </td></tr>
+
+  <!-- Title -->
+  <tr><td style="padding:14px 32px 0 32px;">
+    <h1 style="margin:0;font-family:'General Sans','Hanken Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:24px;font-weight:600;color:#1a1d1c;line-height:1.3;letter-spacing:-0.02em;">Your account was deleted</h1>
+    <p style="margin:8px 0 0 0;font-size:15px;color:#52525b;line-height:1.5;">Your Ninth Inning Email account and all the data tied to it have been permanently deleted. You won&#39;t receive any more recap emails.</p>
+  </td></tr>
+
+  <!-- Come back anytime -->
+  <tr><td style="padding:20px 32px 0 32px;">
+    <p style="margin:0;font-size:14px;color:#3f3f46;line-height:1.55;">Changed your mind? You&#39;re always welcome back &mdash; just sign up again at <a href="${siteUrl}" style="color:${accent};text-decoration:underline;font-weight:600;">ninthinning.email</a>.</p>
+  </td></tr>
+
+  <!-- Footer divider -->
+  <tr><td style="padding:32px 32px 0 32px;">
+    <hr style="margin:0;border:none;border-top:1px solid #e4e4e7;">
+  </td></tr>
+
+  <!-- Disclaimer -->
+  <tr><td style="padding:16px 32px 28px 32px;">
+    <p style="margin:0;font-size:11px;color:#a1a1aa;line-height:1.5;">Ninth Inning Email is not affiliated with, endorsed by, or sponsored by MLB or any MLB club. Questions: <a href="mailto:highlights@ninthinning.email" style="color:#a1a1aa;">highlights@ninthinning.email</a></p>
+  </td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>`;
+}
+
 // Spoiler-safe standings strip (#148). `standing` is the snapshot from the day
 // before first pitch, so the rendered numbers cannot reveal the result of the
 // game being recapped. Returns an empty string when no usable data exists.

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { appendUtmParams, buildEmailHtml, buildWelcomeEmailHtml } from "./email-template";
+import {
+  appendUtmParams,
+  buildAccountDeletedEmailHtml,
+  buildEmailHtml,
+  buildWelcomeEmailHtml,
+} from "./email-template";
 
 const TEAM = { id: 147, name: "New York Yankees", abbr: "NYY", color: "#003087" };
 const HIGHLIGHT_URL = "https://example.com/highlight.mp4";
@@ -378,6 +383,42 @@ describe("buildWelcomeEmailHtml", () => {
     const html = buildWelcomeEmailHtml(USER_ID);
     expect(html).toContain("Forward them this email");
     expect(html).toContain(">ninthinning.email</a>");
+    expect(html).toContain('href="https://ninthinning.email"');
+  });
+});
+
+describe("buildAccountDeletedEmailHtml", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.SITE_URL;
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("confirms the account and its data were deleted", () => {
+    const html = buildAccountDeletedEmailHtml();
+    expect(html).toContain("Your account was deleted");
+    expect(html.toLowerCase()).toContain("permanently deleted");
+  });
+
+  it("includes the non-affiliation disclaimer", () => {
+    const html = buildAccountDeletedEmailHtml();
+    expect(html).toContain("not affiliated with");
+  });
+
+  it("carries no unsubscribe link or tip prompt (the account is gone)", () => {
+    process.env.TIP_URL = "https://buymeacoffee.com/example";
+    const html = buildAccountDeletedEmailHtml();
+    expect(html).not.toContain("/unsubscribe?token=");
+    expect(html).not.toContain("Tip the developer");
+  });
+
+  it("links the come-back-anytime prompt to the site URL", () => {
+    const html = buildAccountDeletedEmailHtml({ siteUrl: "https://ninthinning.email" });
     expect(html).toContain('href="https://ninthinning.email"');
   });
 });


### PR DESCRIPTION
## Summary

Implements #24 — users can now delete their account and all associated data from the dashboard, without contacting support.

- **`DELETE /api/account`** hard-deletes the `auth.users` row. `mlb_user_teams` and `mlb_sent_notifications` both declare `on delete cascade` FKs against `auth.users`, so the cascade drops every related `mlb_*` row in the same database transaction — genuine single-transaction atomicity, no orphan rows for the cron's next run.
- Sends a one-line branded confirmation email (`buildAccountDeletedEmailHtml`). The send is **best-effort** — the deletion is already done and irreversible by the time it fires, so a Brevo failure can't surface as a failed request.
- Clears the session cookie server-side after deletion.
- Dashboard gains an **Account** section with a "Delete account" button behind a typed-`DELETE` confirmation panel.
- Privacy page updated: documents the self-serve flow and the 7-day backup retention window (acceptance criterion #3).

## Changes

| File | Change |
|------|--------|
| `app/api/account/route.js` | New `DELETE` handler |
| `lib/delete-account.js` | `deleteAccount()` helper (cascade delete + best-effort email) |
| `app/dashboard/delete-account.js` | Typed-confirmation client component |
| `app/dashboard/page.js` | Account section |
| `lib/email-template.js` | `buildAccountDeletedEmailHtml()` |
| `app/privacy/page.js` | Self-serve deletion copy + backup retention window |
| `lib/delete-account.test.js`, `lib/email-template.test.js` | 8 new tests |

## Test plan

- [x] `npm test` — 166/166 pass (was 158)
- [x] `npm run build` — compiles cleanly, `/api/account` registered
- [ ] **Manual browser check needed** — could not exercise the golden path in CI (no Supabase credentials in the sandbox; `middleware.js` 500s on every route). Verify on a preview deploy with a throwaway account: dashboard dialog → type `DELETE` → confirm → redirect to `/`, confirmation email arrives, and the `auth.users` + `mlb_*` rows are gone.
- [ ] Re-sign-in with the same email creates a fresh account with no prior team selections

https://claude.ai/code/session_01CJVmRPbyr6ZFArPviBjZsK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJVmRPbyr6ZFArPviBjZsK)_