### PR TITLE
Add pause-notifications toggle for recap emails (#22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,9 @@ Any failure exits non-zero so the operator notices on the next prompt.
   - `api/cron/` — Main cron worker (every 15 min). Early-returns when `mlb_cron_schedule` has no expected_finish_at within (now-2.5h, now+30m); otherwise checks for completed games and sends emails. Logs each non-skipped run to `mlb_cron_runs`. See #76.
   - `api/cron/schedule/` — Daily 9am ET scheduler. Pulls today's MLB slate, writes one wake per game (`first_pitch + 3.5h`) into `mlb_cron_schedule`, prunes rows older than 36h.
   - `api/unsubscribe/` — Unsubscribe API
-  - `dashboard/` — Team selection UI
+  - `api/pause/` — Pause-recaps API (no-login, token = user id; see "Email preferences: pause" below)
+  - `pause/` — Confirmation page for the email-footer "Pause for 7 days" link
+  - `dashboard/` — Team selection UI + email-preferences (pause) control
   - `admin/` — Owner-only health dashboard (gated by `ADMIN_EMAIL` via `notFound()`); shows total users, emails sent in the last 7 days, and recent cron runs. Also exposes break-glass "Run daily scheduler now" / "Run main cron now" buttons (#110) — see "Break-glass recovery" below
   - `login/` — Magic link auth
 - `lib/` — Shared utilities
@@ -410,6 +412,48 @@ A one-time welcome email fires the first time a user adds a team in `/dashboard`
 Idempotency uses a sentinel row in `mlb_sent_notifications` with `game_pk = 0` (no schema change). The helper does claim-then-send: insert the sentinel first, then send. If the insert fails with Postgres `23505` (unique violation), a previous call already won and we skip. If `sendEmail` throws, the sentinel is rolled back so a retry can succeed. This makes "remove all teams, re-add" a no-op — the sentinel persists.
 
 The email template is `buildWelcomeEmailHtml` in `lib/email-template.js`. Same 520px card layout as the recap email but with a brand-green accent (no team color, since there's no team), three "how it works" bullets, and a CTA back to `/dashboard`.
+
+## Email preferences: pause (#22)
+
+First slice of email preferences — a switch to pause recap emails **without**
+unsubscribing or removing teams. State lives in one new table,
+`mlb_user_preferences` (one row per user, `user_id` PK, nullable
+`notifications_paused_until timestamptz`). The row is created lazily — a user
+who never touches the setting has no row.
+
+`runMainCron` (`lib/cron-jobs.js`) batches one extra query against
+`mlb_user_preferences` (`.in(candidateUserIds).gt("notifications_paused_until", now)`)
+and skips any returned user in the fan-out loop with
+`skipped.reason = "notifications_paused"`. The `.gt()` filter does the
+time comparison server-side, so NULL and expired pauses come back as "active"
+for free. On a read error the cron **falls open** (sends) rather than dropping
+everyone's email over a transient blip — same stance as the schedule read.
+
+Two ways to pause:
+
+- **Dashboard** — `app/dashboard/pause-control.js`, a three-way control
+  (Active / Pause for 7 days / Pause indefinitely) under the "Email
+  preferences" section. Writes `mlb_user_preferences` via the browser Supabase
+  client (RLS: users read/write only their own row).
+- **Email footer link** — every recap email carries a "Pause for 7 days" link
+  next to "Unsubscribe", pointing at `/pause?token={userId}`. The `/pause`
+  page POSTs to `/api/pause`, which upserts `now()+7d` via the service-role
+  client — no login required, mirroring the `/api/unsubscribe` token pattern.
+
+`lib/preferences.js` holds the shared logic: `PAUSE_INDEFINITELY` (a
+far-future sentinel — "indefinite" is anything >1y out, robust to Postgres
+timestamptz reformatting), `sevenDayPauseUntil()`, and `pauseState()`
+(maps a stored value to `"active" | "timed" | "indefinite"` for the dashboard).
+
+Re-enabling never replays missed emails — `mlb_sent_notifications` already
+gates that. A pause that lapses (timestamp passes) is silently "active" again.
+
+> **One-time setup:** `mlb_user_preferences` is a new table — run the
+> `create table public.mlb_user_preferences ...` block from
+> `supabase-schema.sql` in the Supabase SQL editor against production (and
+> staging, if provisioned). Until it exists the cron's pause query errors and
+> falls open, so nothing breaks — paused users just keep receiving email until
+> the table is created.
 
 ## Supabase schema conventions
 

--- a/app/api/pause/route.js
+++ b/app/api/pause/route.js
@@ -1,0 +1,32 @@
+import { createAdminClient } from "@/lib/supabase-admin";
+import { sevenDayPauseUntil } from "@/lib/preferences";
+import { NextResponse } from "next/server";
+
+// Pause recap emails for 7 days via an email-footer link — no login required
+// (#22). Mirrors /api/unsubscribe: the token is the user's ID, encoded in the
+// link. Idempotent — re-hitting it just re-extends the 7-day window.
+export async function POST(request) {
+  const { token } = await request.json();
+
+  if (!token) {
+    return NextResponse.json({ error: "Missing token" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+
+  // Upsert so a user with no preferences row yet still pauses cleanly.
+  const { error } = await supabase.from("mlb_user_preferences").upsert(
+    {
+      user_id: token,
+      notifications_paused_until: sevenDayPauseUntil(),
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "user_id" }
+  );
+
+  if (error) {
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/pause/route.test.js
+++ b/app/api/pause/route.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const upsertMock = vi.fn();
+const fromMock = vi.fn();
+const createAdminClient = vi.fn();
+
+vi.mock("@/lib/supabase-admin", () => ({
+  createAdminClient: () => createAdminClient(),
+}));
+
+function makeRequest(body) {
+  return new Request("http://localhost/api/pause", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  upsertMock.mockReturnValue({ error: null });
+  fromMock.mockReturnValue({ upsert: upsertMock });
+  createAdminClient.mockReturnValue({ from: fromMock });
+});
+
+describe("POST /api/pause", () => {
+  it("returns 400 when the token is missing", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({}));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing token" });
+    expect(createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the token is an empty string", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({ token: "" }));
+
+    expect(res.status).toBe(400);
+    expect(createAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("upserts a 7-day pause for the token and returns ok", async () => {
+    const before = Date.now();
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({ token: "user-abc" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(fromMock).toHaveBeenCalledWith("mlb_user_preferences");
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+
+    const [row, options] = upsertMock.mock.calls[0];
+    expect(row.user_id).toBe("user-abc");
+    expect(options).toEqual({ onConflict: "user_id" });
+
+    // notifications_paused_until lands ~7 days out.
+    const pausedUntil = Date.parse(row.notifications_paused_until);
+    const sevenDays = 7 * 24 * 60 * 60 * 1000;
+    expect(pausedUntil).toBeGreaterThanOrEqual(before + sevenDays);
+    expect(pausedUntil).toBeLessThanOrEqual(Date.now() + sevenDays);
+  });
+
+  it("returns 500 when the supabase upsert fails", async () => {
+    upsertMock.mockReturnValueOnce({ error: { message: "boom" } });
+    const { POST } = await import("./route");
+
+    const res = await POST(makeRequest({ token: "user-abc" }));
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed" });
+  });
+});

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -5,6 +5,7 @@ import { MLB_TEAMS } from "@/lib/teams";
 import TeamGrid from "./team-grid";
 import SignupTracker from "./signup-tracker";
 import DeleteAccount from "./delete-account";
+import PauseControl from "./pause-control";
 import { Suspense } from "react";
 import pkg from "../../package.json";
 import { BrandLockup } from "@/components/brand";
@@ -31,6 +32,15 @@ export default async function DashboardPage() {
   const followedIds = new Set((userTeams || []).map((r) => r.team_id));
   const followedCount = followedIds.size;
   const tipUrl = process.env.TIP_URL;
+
+  // Email preferences (#22). A missing row is the common case (lazily created
+  // on first change) — maybeSingle() returns null without erroring.
+  const { data: pref } = await supabase
+    .from("mlb_user_preferences")
+    .select("notifications_paused_until")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const pausedUntil = pref?.notifications_paused_until ?? null;
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -109,6 +119,17 @@ export default async function DashboardPage() {
             )}
 
             <TeamGrid teams={MLB_TEAMS} followedIds={[...followedIds]} />
+
+            <div className="mt-16 border-t border-[#1f3a2c] pt-8">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-[#a8a299]">
+                Email preferences
+              </h2>
+              <p className="mt-2 max-w-prose text-sm text-[#a8a299]">
+                Need a break? Pause recap emails without unsubscribing or
+                removing teams — the teams you follow stay exactly as they are.
+              </p>
+              <PauseControl pausedUntil={pausedUntil} />
+            </div>
 
             <div className="mt-16 border-t border-[#1f3a2c] pt-8">
               <h2 className="text-xs font-semibold uppercase tracking-wider text-[#a8a299]">

--- a/app/dashboard/pause-control.js
+++ b/app/dashboard/pause-control.js
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase-browser";
+import { PAUSE_INDEFINITELY, pauseState, sevenDayPauseUntil } from "@/lib/preferences";
+
+const OPTIONS = [
+  {
+    id: "active",
+    label: "Active",
+    desc: "Recaps arrive the morning after every game.",
+  },
+  {
+    id: "timed",
+    label: "Pause for 7 days",
+    desc: "Recaps stop for a week, then resume automatically.",
+  },
+  {
+    id: "indefinite",
+    label: "Pause indefinitely",
+    desc: "Recaps stop until you switch this back to Active.",
+  },
+];
+
+const dateFmt = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+export default function PauseControl({ pausedUntil: initialPausedUntil }) {
+  const [pausedUntil, setPausedUntil] = useState(initialPausedUntil ?? null);
+  const [pendingId, setPendingId] = useState(null);
+  const [error, setError] = useState(null);
+  const [, startTransition] = useTransition();
+  const router = useRouter();
+
+  const current = pauseState(pausedUntil);
+
+  async function select(optionId) {
+    if (optionId === current || pendingId) return;
+    setPendingId(optionId);
+    setError(null);
+
+    const valueByOption = {
+      active: null,
+      timed: sevenDayPauseUntil(),
+      indefinite: PAUSE_INDEFINITELY,
+    };
+    const nextValue = valueByOption[optionId];
+
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    const { error: writeError } = await supabase
+      .from("mlb_user_preferences")
+      .upsert(
+        {
+          user_id: user.id,
+          notifications_paused_until: nextValue,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id" }
+      );
+
+    if (writeError) {
+      setError("Couldn't save that change. Please try again.");
+      setPendingId(null);
+      return;
+    }
+
+    setPausedUntil(nextValue);
+    setPendingId(null);
+    startTransition(() => router.refresh());
+  }
+
+  return (
+    <div className="mt-4">
+      <div role="radiogroup" aria-label="Recap email schedule" className="flex flex-col gap-2">
+        {OPTIONS.map((option) => {
+          const isActive = option.id === current;
+          const isPending = option.id === pendingId;
+          // The timed option is `isActive` only when `current === "timed"`, so
+          // pausedUntil here is the live resume instant.
+          const showResumeDate = isActive && option.id === "timed";
+          return (
+            <button
+              key={option.id}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              disabled={pendingId !== null}
+              onClick={() => select(option.id)}
+              className={`flex w-full items-start gap-3 rounded-xl border px-4 py-3 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-[#4a7a5b] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0f1311] disabled:cursor-not-allowed ${
+                isActive
+                  ? "border-[#4a7a5b] bg-[#0f2a1f]/80"
+                  : "border-[#1f3a2c] bg-[#0f2a1f]/40 hover:border-[#4a7a5b] hover:bg-[#0f2a1f]/60"
+              } ${pendingId !== null && !isPending ? "opacity-50" : ""}`}
+            >
+              <span
+                aria-hidden="true"
+                className={`mt-0.5 flex h-4 w-4 flex-none items-center justify-center rounded-full border ${
+                  isActive ? "border-[#5a9a6f]" : "border-[#3a5a47]"
+                }`}
+              >
+                {isActive && (
+                  <span className="h-2 w-2 rounded-full bg-[#5a9a6f]" />
+                )}
+              </span>
+              <span className="flex-1">
+                <span className="block text-sm font-semibold text-[#f7f5ef]">
+                  {option.label}
+                  {isPending && (
+                    <span className="ml-2 text-xs font-normal text-[#a8a299]">
+                      Saving…
+                    </span>
+                  )}
+                </span>
+                <span className="mt-0.5 block text-xs text-[#a8a299]">
+                  {showResumeDate
+                    ? `Recaps resume ${dateFmt.format(new Date(pausedUntil))}.`
+                    : option.desc}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      {error && (
+        <p role="alert" className="mt-3 text-sm text-[#e09b99]">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/pause/page.js
+++ b/app/pause/page.js
@@ -1,0 +1,69 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+function PauseForm() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+  const [status, setStatus] = useState("idle"); // idle | loading | done | error
+
+  async function handlePause() {
+    setStatus("loading");
+    const res = await fetch("/api/pause", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    setStatus(res.ok ? "done" : "error");
+  }
+
+  if (status === "done") {
+    return (
+      <div className="text-center">
+        <h1 className="text-2xl font-bold">Recaps paused for 7 days</h1>
+        <p className="mt-3 text-gray-400">
+          You won&apos;t receive recap emails for the next week — they resume
+          automatically after that. Your followed teams are unchanged. Want a
+          different setting? Manage it anytime from your{" "}
+          <a href="/dashboard" className="underline">
+            dashboard
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center">
+      <h1 className="text-2xl font-bold">Pause for 7 days</h1>
+      <p className="mt-3 text-gray-400">
+        Click below to pause all recap emails for the next 7 days. Your teams
+        stay followed and recaps resume automatically — no need to re-subscribe.
+      </p>
+      <button
+        onClick={handlePause}
+        disabled={status === "loading"}
+        className="mt-6 rounded-lg bg-[#2d5a3d] px-6 py-3 text-sm font-semibold text-white hover:bg-[#356b49] disabled:opacity-50 transition"
+      >
+        {status === "loading" ? "Processing..." : "Pause for 7 days"}
+      </button>
+      {status === "error" && (
+        <p className="mt-3 text-sm text-red-400">
+          Something went wrong. Please try again.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function PausePage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center px-6">
+      <Suspense>
+        <PauseForm />
+      </Suspense>
+    </main>
+  );
+}

--- a/lib/cron-jobs.integration.test.js
+++ b/lib/cron-jobs.integration.test.js
@@ -163,7 +163,9 @@ const USERS = [
 
 // Builds a Supabase stub rich enough for the whole runMainCron pipeline and
 // records every write so the test can assert side effects were/weren't taken.
-function makeSupabaseMock() {
+// `pausedUserIds` is the set the mlb_user_preferences query reports as paused
+// (the .gt() time filter is the DB's job — the mock returns the filtered set).
+function makeSupabaseMock({ pausedUserIds = [] } = {}) {
   const writes = {
     cronRunInserts: [],
     cronRunUpdates: [],
@@ -238,6 +240,17 @@ function makeSupabaseMock() {
               writes.sentInserts.push(row);
               return { error: null };
             },
+          };
+        case "mlb_user_preferences":
+          return {
+            select: () => ({
+              in: () => ({
+                gt: async () => ({
+                  data: pausedUserIds.map((id) => ({ user_id: id })),
+                  error: null,
+                }),
+              }),
+            }),
           };
         default:
           throw new Error(`Unexpected table: ${table}`);
@@ -432,5 +445,36 @@ describe("runMainCron — end-to-end dry run, multi-game multi-subscriber (#180)
     expect(sendEmail).toHaveBeenCalledTimes(4);
     expect(writes.sentInserts).toHaveLength(4);
     expect(writes.cronRunUpdates.some((u) => u.status === "success")).toBe(true);
+  });
+
+  it("skips paused subscribers across every game they would receive (#22)", async () => {
+    // user-3 follows both the Yankees and the Dodgers — pausing them must drop
+    // both their Game A and Game B emails. user-1 (Yankees only) is paused too.
+    // The baseline fan-out is 4 emails; with user-1 and user-3 paused only
+    // user-2 (Red Sox, Game A) is left.
+    const { client, writes } = makeSupabaseMock({ pausedUserIds: ["user-1", "user-3"] });
+
+    const result = await runMainCron({ supabase: client, force: true });
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+    expect(sendEmail).toHaveBeenCalledWith(
+      "redsox-fan@example.com",
+      expect.any(String),
+      expect.any(String),
+      undefined
+    );
+    expect(writes.sentInserts).toEqual([
+      { user_id: "user-2", game_pk: GAME_A },
+    ]);
+    expect(result.body.message).toMatch(/sent 1 emails/);
+  });
+
+  it("omits paused subscribers from the dry-run report (#22)", async () => {
+    const { client } = makeSupabaseMock({ pausedUserIds: ["user-1", "user-3"] });
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    const recipients = result.body.dryRunReport.map((r) => r.email);
+    expect(recipients).toEqual(["redsox-fan@example.com"]);
   });
 });

--- a/lib/cron-jobs.js
+++ b/lib/cron-jobs.js
@@ -392,6 +392,27 @@ export async function runMainCron({
       }
     }
 
+    // Recipients who have paused recap emails (#22). One batched query against
+    // mlb_user_preferences; the .gt() filter excludes NULL and past timestamps
+    // server-side, so only currently-paused users come back. On error we fall
+    // open (send) rather than dropping everyone's email over a transient blip —
+    // consistent with the schedule-read fall-open above.
+    const pausedUserIds = new Set();
+    if (candidateUserIdList.length > 0) {
+      const { data: pausedRows, error: pausedError } = await supabase
+        .from("mlb_user_preferences")
+        .select("user_id")
+        .in("user_id", candidateUserIdList)
+        .gt("notifications_paused_until", new Date().toISOString());
+      if (pausedError) {
+        console.error("mlb_user_preferences batch read failed:", pausedError.message);
+      } else {
+        for (const row of pausedRows || []) {
+          pausedUserIds.add(row.user_id);
+        }
+      }
+    }
+
     for (const game of newGames) {
       const subscriberUserIds = subscribersByTeamId.get(game.teamId) || [];
       if (subscriberUserIds.length === 0) {
@@ -408,6 +429,11 @@ export async function runMainCron({
 
         if (alreadySent.has(`${userId}:${game.gamePk}`)) {
           skipped.push({ gamePk: game.gamePk, reason: "already_notified" });
+          continue;
+        }
+
+        if (pausedUserIds.has(userId)) {
+          skipped.push({ gamePk: game.gamePk, userId, reason: "notifications_paused" });
           continue;
         }
 

--- a/lib/cron-jobs.test.js
+++ b/lib/cron-jobs.test.js
@@ -75,7 +75,10 @@ function makeContentWithHighlight(url = HIGHLIGHT_URL) {
 //   undefined  → no row in cache (fresh game, never checked)
 //   null       → row exists with highlight_url = null (checked, no highlight yet)
 //   string     → row exists with a real URL (highlight already found)
-function makeSupabaseMock({ cachedHighlightUrl = undefined } = {}) {
+// `pausedUserIds`: user ids the mlb_user_preferences query reports as currently
+//   paused (the .gt() time filter is the DB's job — the mock just returns the
+//   already-filtered set).
+function makeSupabaseMock({ cachedHighlightUrl = undefined, pausedUserIds = [] } = {}) {
   const sentInsert = vi.fn(async () => ({ error: null }));
   const cacheUpsert = vi.fn(async () => ({ error: null }));
   const cronRunInsert = vi.fn();
@@ -147,6 +150,18 @@ function makeSupabaseMock({ cachedHighlightUrl = undefined } = {}) {
             }),
           }),
           insert: sentInsert,
+        };
+      }
+      if (table === "mlb_user_preferences") {
+        return {
+          select: () => ({
+            in: () => ({
+              gt: async () => ({
+                data: pausedUserIds.map((id) => ({ user_id: id })),
+                error: null,
+              }),
+            }),
+          }),
         };
       }
       throw new Error(`Unexpected table: ${table}`);
@@ -291,5 +306,48 @@ describe("runMainCron — dry-run mode (#180)", () => {
 
     expect(result.body.dryRunReport).toBeUndefined();
     expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runMainCron — paused-notification skip (#22)", () => {
+  it("sends no email and writes no dedup row for a paused subscriber", async () => {
+    const { client, sentInsert } = makeSupabaseMock({
+      cachedHighlightUrl: HIGHLIGHT_URL,
+      pausedUserIds: [USER_ID],
+    });
+    fetchDailySchedule.mockResolvedValue(makeDailySchedule());
+
+    const result = await runMainCron({ supabase: client, force: true });
+
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(sentInsert).not.toHaveBeenCalled();
+    expect(result.body.message).toMatch(/sent 0 emails/);
+    expect(result.body.skipped).toContainEqual(
+      expect.objectContaining({ userId: USER_ID, reason: "notifications_paused" })
+    );
+  });
+
+  it("still emails a subscriber who is not paused", async () => {
+    const { client } = makeSupabaseMock({
+      cachedHighlightUrl: HIGHLIGHT_URL,
+      pausedUserIds: [],
+    });
+    fetchDailySchedule.mockResolvedValue(makeDailySchedule());
+
+    await runMainCron({ supabase: client, force: true });
+
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits a paused subscriber from the dry-run report", async () => {
+    const { client } = makeSupabaseMock({
+      cachedHighlightUrl: HIGHLIGHT_URL,
+      pausedUserIds: [USER_ID],
+    });
+    fetchDailySchedule.mockResolvedValue(makeDailySchedule());
+
+    const result = await runMainCron({ supabase: client, force: true, dryRun: true });
+
+    expect(result.body.dryRunReport).toEqual([]);
   });
 });

--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -293,6 +293,7 @@ export function buildEmailHtml(
 ) {
   const siteUrl = getSiteUrl(siteUrlOverride);
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
+  const pauseUrl = `${siteUrl}/pause?token=${userId}`;
   const tipUrl = tipUrlOverride ?? process.env.TIP_URL;
   const teamName = team?.name || "Your team";
   const teamColor = team?.color || "#2563eb";
@@ -386,6 +387,8 @@ export function buildEmailHtml(
           <span style="font-size:12px;color:#a1a1aa;">Spoiler-free MLB recaps</span>
         </td>
         <td align="right" style="font-size:12px;vertical-align:top;">
+          <a href="${pauseUrl}" style="color:#a1a1aa;text-decoration:underline;">Pause for 7 days</a>
+          <span style="color:#d4d4d8;">&nbsp;&middot;&nbsp;</span>
           <a href="${unsubscribeUrl}" style="color:#a1a1aa;text-decoration:underline;">Unsubscribe</a>
         </td>
       </tr>

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -117,6 +117,15 @@ describe("buildEmailHtml", () => {
     expect(html).toContain(">Unsubscribe<");
   });
 
+  it("includes a pause-for-7-days footer link with the user token (#22)", () => {
+    process.env.SITE_URL = "https://ninthinning.email";
+    const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE);
+    expect(html).toContain(
+      `https://ninthinning.email/pause?token=${USER_ID}`
+    );
+    expect(html).toContain(">Pause for 7 days<");
+  });
+
   it("includes a forward-to-a-fan prompt linking to the site", () => {
     process.env.SITE_URL = "https://ninthinning.email";
     const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE);

--- a/lib/preferences.js
+++ b/lib/preferences.js
@@ -1,0 +1,34 @@
+// Email-preference helpers (#22).
+//
+// `notifications_paused_until` in mlb_user_preferences gates recap sends in
+// runMainCron:
+//   null / past instant -> active: recaps send normally
+//   future instant      -> paused: the cron skips this user
+//
+// "Pause for 7 days" stores now()+7d; "Pause indefinitely" stores the
+// far-future sentinel below. The dashboard reads the value back through
+// pauseState() to tell an indefinite pause apart from a timed one without
+// needing an exact-string match (Postgres normalizes timestamptz formatting).
+
+export const PAUSE_INDEFINITELY = "9999-12-31T00:00:00.000Z";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Anything further out than this is treated as an indefinite pause. A timed
+// pause is only ever 7 days, so the gap is large and unambiguous.
+const INDEFINITE_THRESHOLD_MS = 365 * 24 * 60 * 60 * 1000;
+
+// ISO timestamp 7 days from `now`, the value a "Pause for 7 days" action writes.
+export function sevenDayPauseUntil(now = Date.now()) {
+  return new Date(now + SEVEN_DAYS_MS).toISOString();
+}
+
+// Maps a stored notifications_paused_until value to a UI state:
+// "active" | "timed" | "indefinite".
+export function pauseState(pausedUntil, now = Date.now()) {
+  if (!pausedUntil) return "active";
+  const until = new Date(pausedUntil).getTime();
+  if (Number.isNaN(until) || until <= now) return "active";
+  if (until > now + INDEFINITE_THRESHOLD_MS) return "indefinite";
+  return "timed";
+}

--- a/lib/preferences.test.js
+++ b/lib/preferences.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { PAUSE_INDEFINITELY, pauseState, sevenDayPauseUntil } from "./preferences";
+
+const NOW = Date.parse("2026-05-21T12:00:00.000Z");
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("sevenDayPauseUntil", () => {
+  it("returns an ISO timestamp exactly 7 days after now", () => {
+    const out = sevenDayPauseUntil(NOW);
+    expect(out).toBe(new Date(NOW + 7 * DAY).toISOString());
+    expect(Date.parse(out) - NOW).toBe(7 * DAY);
+  });
+});
+
+describe("pauseState", () => {
+  it("treats null/undefined as active", () => {
+    expect(pauseState(null, NOW)).toBe("active");
+    expect(pauseState(undefined, NOW)).toBe("active");
+  });
+
+  it("treats a past timestamp as active (the pause has expired)", () => {
+    expect(pauseState(new Date(NOW - DAY).toISOString(), NOW)).toBe("active");
+  });
+
+  it("treats an unparseable value as active rather than throwing", () => {
+    expect(pauseState("not a date", NOW)).toBe("active");
+  });
+
+  it("classifies a 7-day pause as timed", () => {
+    expect(pauseState(sevenDayPauseUntil(NOW), NOW)).toBe("timed");
+  });
+
+  it("classifies the far-future sentinel as indefinite", () => {
+    expect(pauseState(PAUSE_INDEFINITELY, NOW)).toBe("indefinite");
+  });
+
+  it("classifies the sentinel as indefinite even after timestamptz reformatting", () => {
+    // Postgres returns timestamptz as e.g. "9999-12-31T00:00:00+00:00" — a
+    // different string than the stored sentinel, but the same instant.
+    expect(pauseState("9999-12-31T00:00:00+00:00", NOW)).toBe("indefinite");
+  });
+});

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -64,6 +64,35 @@ create policy "Users can view their own MLB notifications"
   on public.mlb_sent_notifications for select
   using (auth.uid() = user_id);
 
+-- User email preferences (#22). One row per user, created lazily the first
+-- time the user changes a preference (dashboard) or pauses via an email
+-- footer link. notifications_paused_until gates recap sends in the main cron:
+--   NULL or <= now()  -> active: recaps send normally
+--   > now()           -> paused: runMainCron skips this user
+-- "Pause for 7 days" stores now()+7d; "Pause indefinitely" stores a
+-- far-future sentinel. See lib/preferences.js.
+create table public.mlb_user_preferences (
+  user_id uuid references auth.users(id) on delete cascade primary key,
+  notifications_paused_until timestamptz,
+  updated_at timestamptz default now() not null
+);
+
+alter table public.mlb_user_preferences enable row level security;
+
+-- Users can read and write only their own preferences row. The main cron
+-- reads this table via service_role, which bypasses RLS.
+create policy "Users can view their own preferences"
+  on public.mlb_user_preferences for select
+  using (auth.uid() = user_id);
+
+create policy "Users can insert their own preferences"
+  on public.mlb_user_preferences for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can update their own preferences"
+  on public.mlb_user_preferences for update
+  using (auth.uid() = user_id);
+
 -- Create a view to join mlb_user_teams with auth.users for the cron worker
 -- (The cron worker uses the service role key which bypasses RLS)
 create view public.mlb_users as


### PR DESCRIPTION
## Summary

First slice of email preferences (#22): a switch to pause recap emails **without** unsubscribing or removing teams.

- **New table `mlb_user_preferences`** — `user_id` PK, nullable `notifications_paused_until`, created lazily on first change. (SQL already applied to production by the repo owner.)
- **Cron skip** — `runMainCron` batches one extra query (`.in(candidateUsers).gt("notifications_paused_until", now)`) and skips paused recipients in the fan-out with skip reason `notifications_paused`. The `.gt()` filter does the time comparison server-side, so NULL/expired pauses read as "active" for free. On a read error the cron **falls open** (sends) rather than dropping everyone's email over a transient blip — same stance as the schedule read.
- **Dashboard control** — three-way control (Active / Pause for 7 days / Pause indefinitely) under a new "Email preferences" section, writing via the browser Supabase client under RLS.
- **Email footer link** — every recap email now carries a "Pause for 7 days" link next to "Unsubscribe" → `/pause?token={userId}` → `/api/pause`, no login required, mirroring the unsubscribe token pattern.
- **`lib/preferences.js`** — shared logic: `PAUSE_INDEFINITELY` sentinel, `sevenDayPauseUntil()`, `pauseState()`.

Re-enabling never replays missed emails — `mlb_sent_notifications` already gates that. A lapsed timed pause silently reverts to "active".

## Test plan

- [x] `npm test` — 183 tests pass (up from 166)
- [x] New coverage: cron pause-skip in both `cron-jobs.test.js` and `cron-jobs.integration.test.js`, plus `lib/preferences.test.js` and `app/api/pause/route.test.js`
- [x] `next build` succeeds with new `/pause` and `/api/pause` routes
- [x] `/pause` page renders (200); `/api/pause` returns 400 on missing token
- [ ] Live-check the dashboard "Email preferences" control once deployed (couldn't test the logged-in dashboard UI without real Supabase credentials in the dev sandbox)
- [ ] Confirm a real recap email shows the "Pause for 7 days" footer link

https://claude.ai/code/session_01GdU7xPnDZKugHeiGg1bSMk

---
_Generated by [Claude Code](https://claude.ai/code/session_01GdU7xPnDZKugHeiGg1bSMk)_