### PR TITLE
Fix duplicate canonical URLs flagged by Search Console

### DIFF
--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -5,6 +5,10 @@ import BreakGlass from "./break-glass";
 
 export const dynamic = "force-dynamic";
 
+export const metadata = {
+  robots: { index: false },
+};
+
 const STATUS_COLORS = {
   success: "text-green-400",
   partial: "text-yellow-400",

--- a/app/dashboard/layout.js
+++ b/app/dashboard/layout.js
@@ -1,0 +1,7 @@
+export const metadata = {
+  robots: { index: false },
+};
+
+export default function DashboardLayout({ children }) {
+  return children;
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -11,7 +11,6 @@ export const metadata = {
   description:
     "Spoiler-free MLB game recap videos delivered to your inbox the morning after. No scores, no spoilers — just the highlights.",
   keywords: ["MLB", "baseball", "highlights", "spoiler-free", "recap", "email"],
-  alternates: { canonical: "/" },
   openGraph: {
     title: "Ninth Inning Email — Spoiler-Free MLB Game Recaps",
     description:

--- a/app/login/layout.js
+++ b/app/login/layout.js
@@ -1,0 +1,7 @@
+export const metadata = {
+  robots: { index: false },
+};
+
+export default function LoginLayout({ children }) {
+  return children;
+}

--- a/app/page.js
+++ b/app/page.js
@@ -3,6 +3,10 @@ import { TEAMS_BY_ID } from "@/lib/teams";
 import { createClient } from "@/lib/supabase-server";
 import { BrandLockup, DiamondGlyph } from "@/components/brand";
 
+export const metadata = {
+  alternates: { canonical: "/" },
+};
+
 const PREVIEW_TEAM_ID = 119; // Dodgers — matches default in app/api/test-email/route.js
 
 function EmailPreview({ size = "sm", showInboxRow = false }) {

--- a/app/pause/layout.js
+++ b/app/pause/layout.js
@@ -1,0 +1,7 @@
+export const metadata = {
+  robots: { index: false },
+};
+
+export default function PauseLayout({ children }) {
+  return children;
+}

--- a/app/robots.js
+++ b/app/robots.js
@@ -1,0 +1,12 @@
+const SITE_URL = process.env.SITE_URL || "https://ninthinning.email";
+
+export default function robots() {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/", "/architecture.html"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,0 +1,16 @@
+const SITE_URL = process.env.SITE_URL || "https://ninthinning.email";
+
+export default function sitemap() {
+  return [
+    {
+      url: SITE_URL,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/privacy`,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+  ];
+}

--- a/app/unsubscribe/layout.js
+++ b/app/unsubscribe/layout.js
@@ -1,0 +1,7 @@
+export const metadata = {
+  robots: { index: false },
+};
+
+export default function UnsubscribeLayout({ children }) {
+  return children;
+}


### PR DESCRIPTION
## Summary

Google Search Console reported **"Duplicate without user-selected canonical"**. The root cause: `app/layout.js` set `alternates: { canonical: "/" }` in the **root** layout, which Next.js cascades to every page. So `/login`, `/dashboard`, `/dashboard/highlights`, `/admin`, `/pause`, and `/unsubscribe` all emitted `<link rel="canonical" href="https://ninthinning.email/">`. When many distinct pages all claim one canonical, Google distrusts the signal, ignores it, and clusters the pages itself.

## Changes

- **`app/layout.js`** — removed the leaking site-wide `canonical: "/"`.
- **`app/page.js`** — homepage now declares its own `canonical: "/"`.
- **`noindex` on non-content pages** so they leave the index and stop forming duplicate clusters: `app/admin/page.js` directly, plus new pass-through layouts for `/login`, `/pause`, `/unsubscribe`, and `/dashboard` (the client-component pages can't export `metadata`; the dashboard layout also covers `/dashboard/highlights`).
- **`app/robots.js` / `app/sitemap.js`** (new) — generate `/robots.txt` and `/sitemap.xml`; the sitemap lists only the two indexable URLs (`/` and `/privacy`), giving Google an authoritative list. `/privacy` already had a correct per-page canonical and is unchanged.

## Test plan

- [x] `vitest run` — all 183 tests pass
- [x] `next build` succeeds; `/robots.txt` and `/sitemap.xml` appear in the route manifest
- [ ] After deploy, verify `/login` etc. emit `<meta name="robots" content="noindex">` and only `/` emits a canonical
- [ ] In Search Console, **Validate Fix** on the issue and submit `https://ninthinning.email/sitemap.xml`

https://claude.ai/code/session_01MnnSa9DpAbke9XfkUT7rfS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnnSa9DpAbke9XfkUT7rfS)_