### PR TITLE
Add branded highlights landing page and route recap CTA through it (#77)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Any failure exits non-zero so the operator notices on the next prompt.
   - `api/unsubscribe/` — Unsubscribe API
   - `api/pause/` — Pause-recaps API (no-login, token = user id; see "Email preferences: pause" below)
   - `pause/` — Confirmation page for the email-footer "Pause for 7 days" link
+  - `highlights/[gamePk]/` — Branded interstitial the recap-email "Watch Highlights" CTA links to (#77); embeds the MLB highlight in our chrome. See "Branded highlights page" below
   - `dashboard/` — Team selection UI + email-preferences (pause) control
   - `admin/` — Owner-only health dashboard (gated by `ADMIN_EMAIL` via `notFound()`); shows total users, emails sent in the last 7 days, and recent cron runs. Also exposes break-glass "Run daily scheduler now" / "Run main cron now" buttons (#110) — see "Break-glass recovery" below
   - `login/` — Magic link auth
@@ -402,8 +403,44 @@ Events currently captured:
 | `signup_completed` | `app/dashboard/signup-tracker.js` | The auth callback (`app/auth/callback/route.js`) appends `?signup=1` when `auth.users.created_at` is < 5 min old; the dashboard tracker fires once and strips the param via `router.replace` so a refresh doesn't double-count |
 | `team_selected` / `team_deselected` | `app/dashboard/team-grid.js` | Includes `team_id` in props; fired after the Supabase write resolves |
 | `unsubscribe_clicked` | `app/unsubscribe/page.js` | Anonymous (no user session), but PostHog distinct_id persists across visits |
+| `highlights_page_viewed` | `app/highlights/[gamePk]/view-tracker.js` | Fired once on mount of the branded highlights page (#77); props carry `game_pk` and `team_id`. Often anonymous — most visits arrive from an email link |
 
 Autocapture and session recording are disabled — only the explicit events above. Pageviews and pageleaves are captured automatically by PostHog. To add a new event, import `track` from `@/lib/analytics` and call it from a `"use client"` component.
+
+## Branded highlights page (#77)
+
+The recap email's "Watch Highlights" CTA no longer links straight to MLB.com.
+It points at `app/highlights/[gamePk]/page.js` — a branded interstitial on
+`ninthinning.email` that wraps the highlight in our chrome, so the
+highest-intent click in the funnel lands on a page we own and can instrument.
+
+- **Public, no auth.** Matches the email-link UX — anyone with the link can
+  view it. Reads `mlb_game_cache` (RLS: publicly readable) for the game.
+- **Data source.** Keyed only on `game_pk`. The cron always writes a
+  `mlb_game_cache` row for every game it emails about, so the row is the
+  source of truth. An unknown `game_pk` (or a non-numeric path segment)
+  `notFound()`s. If the cached `highlight_url` is null (cron cached the row
+  before MLB published a recap) the page makes one live `fetchGameContent` +
+  `extractHighlightUrl` retry; still-missing degrades to a "not posted yet"
+  state, never a broken player.
+- **Player.** When `highlight_url` is a direct `.mp4` (the common case —
+  `pickPlaybackUrl` in `lib/mlb.js` prefers `mp4Avc`/`2500K` playbacks) it
+  renders a native `<video controls preload="metadata">`. Non-mp4 URLs (e.g.
+  HLS) fall back to a branded "Watch the recap" handoff button. There is no
+  third-party MLB player embed.
+- **Spoiler-safe context.** Title is `{Team} highlights` + the long-form
+  date; an opponent line (`vs/@ {Opponent} · Game X of Y`) is derived
+  best-effort from a `fetchSchedule` call and `extractSeriesContext` — any
+  failure just omits the line. No score, win/loss, or play-by-play anywhere.
+- **CTA wiring.** `recapCtaUrl()` in `lib/email-template.js` builds
+  `{SITE_URL}/highlights/{gamePk}` (with the standard recap UTM params) for
+  both `buildEmailHtml` and the multi-game `renderGameCard`. `gamePk` is
+  threaded in from `lib/cron-jobs.js` and `lib/resend-recap.js`. When no
+  `gamePk` is supplied the CTA falls back to the raw highlight URL.
+- **Analytics.** `highlights_page_viewed` fires from the `view-tracker.js`
+  client island (see the product-analytics table above).
+- Per-game pages are `robots: { index: false }` and excluded from the
+  sitemap — no SEO value, and they expose internal game PKs.
 
 ## Welcome email (#26)
 

--- a/app/admin/actions.test.js
+++ b/app/admin/actions.test.js
@@ -194,7 +194,8 @@ describe("resendLatestRecapAction", () => {
     expect(subject.startsWith("[TEST] ")).toBe(true);
     expect(subject).toContain("New York Yankees Highlights");
     expect(html).toContain("New York Yankees");
-    expect(html).toContain("https://mlb.com/video/yankees-recap");
+    // The recap CTA routes through our branded highlights page (#77).
+    expect(html).toContain(`/highlights/${gamePk}`);
   });
 
   it("is blocked when EMAILS_PAUSED is set", async () => {

--- a/app/highlights/[gamePk]/page.js
+++ b/app/highlights/[gamePk]/page.js
@@ -1,0 +1,280 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { BrandLockup } from "@/components/brand";
+import { TEAMS_BY_ID } from "@/lib/teams";
+import { createClient } from "@/lib/supabase-server";
+import {
+  extractHighlightUrl,
+  extractSeriesContext,
+  fetchGameContent,
+  fetchSchedule,
+  formatDisplayDate,
+} from "@/lib/mlb";
+import HighlightsViewTracker from "./view-tracker";
+
+// Per-game pages carry no SEO value and reference internal game PKs — keep
+// them out of search indexes.
+export const metadata = {
+  title: "Game highlights",
+  description: "Watch the spoiler-free recap of your team's game.",
+  robots: { index: false },
+};
+
+function parseGamePk(raw) {
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+// Spoiler-safe opponent line, e.g. "vs Yankees · Game 2 of 3". The series
+// position is dropped if the numbers are missing or malformed — mirrors the
+// recap email's seriesContextLine so the two surfaces never disagree (#69).
+function seriesLine(seriesContext) {
+  if (!seriesContext) return null;
+  const { opponentName, isHome, seriesGameNumber, gamesInSeries } = seriesContext;
+  if (!opponentName) return null;
+  let line = `${isHome ? "vs" : "@"} ${opponentName}`;
+  if (
+    Number.isInteger(seriesGameNumber) &&
+    seriesGameNumber >= 1 &&
+    Number.isInteger(gamesInSeries) &&
+    gamesInSeries >= 1 &&
+    seriesGameNumber <= gamesInSeries
+  ) {
+    line += ` · Game ${seriesGameNumber} of ${gamesInSeries}`;
+  }
+  return line;
+}
+
+// The email CTA only ever links to games the cron has already processed, so a
+// mlb_game_cache row is the source of truth. An unknown gamePk 404s rather than
+// guessing. The highlight URL is normally cached on that row; if the cron wrote
+// the row before MLB published a recap we make one live re-fetch attempt.
+async function loadGame(gamePk) {
+  const supabase = await createClient();
+  const { data: cached } = await supabase
+    .from("mlb_game_cache")
+    .select("game_pk, team_id, game_date, highlight_url")
+    .eq("game_pk", gamePk)
+    .maybeSingle();
+
+  if (!cached) return null;
+
+  let highlightUrl = cached.highlight_url;
+  if (!highlightUrl) {
+    try {
+      highlightUrl = extractHighlightUrl(await fetchGameContent(gamePk));
+    } catch {
+      // Leave null — the page degrades to a "not posted yet" state.
+    }
+  }
+
+  let seriesContext = null;
+  try {
+    const schedule = await fetchSchedule(cached.team_id, cached.game_date);
+    const game = (schedule?.dates?.[0]?.games || []).find(
+      (g) => g.gamePk === gamePk
+    );
+    const raw = game ? extractSeriesContext(game, cached.team_id) : null;
+    const opponent = raw ? TEAMS_BY_ID[raw.opponentId] : null;
+    if (opponent) {
+      seriesContext = {
+        opponentName: opponent.shortName,
+        isHome: raw.isHome,
+        seriesGameNumber: raw.seriesGameNumber,
+        gamesInSeries: raw.gamesInSeries,
+      };
+    }
+  } catch {
+    // The opponent line is optional context — omit it on any failure.
+  }
+
+  return {
+    gamePk,
+    teamId: cached.team_id,
+    gameDate: cached.game_date,
+    highlightUrl,
+    seriesContext,
+  };
+}
+
+function NextStepCard({ href, external, title, body }) {
+  const className =
+    "block rounded-xl border border-[#1f3a2c] bg-[#0f2a1f]/40 px-5 py-4 transition hover:border-[#3f6e57]";
+  const inner = (
+    <>
+      <span className="text-sm font-semibold text-[#f7f5ef]">{title}</span>
+      <span className="mt-1 block text-sm text-[#a8a299]">{body}</span>
+    </>
+  );
+  return external ? (
+    <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+      {inner}
+    </a>
+  ) : (
+    <Link href={href} className={className}>
+      {inner}
+    </Link>
+  );
+}
+
+export default async function HighlightsPage({ params }) {
+  const { gamePk: gamePkParam } = await params;
+  const gamePk = parseGamePk(gamePkParam);
+  if (!gamePk) notFound();
+
+  const game = await loadGame(gamePk);
+  if (!game) notFound();
+
+  const team = TEAMS_BY_ID[game.teamId];
+  const teamName = team?.name || "Your team";
+  const teamColor = team?.color || "#2d5a3d";
+  const displayDate = formatDisplayDate(game.gameDate);
+  const series = seriesLine(game.seriesContext);
+  const tipUrl = process.env.TIP_URL;
+  const { highlightUrl } = game;
+  const isMp4 =
+    typeof highlightUrl === "string" && /\.mp4(\?|$)/i.test(highlightUrl);
+
+  return (
+    <div className="min-h-screen">
+      <HighlightsViewTracker gamePk={gamePk} teamId={game.teamId} />
+
+      <header className="mx-auto flex max-w-3xl items-center justify-between px-6 py-5">
+        <Link
+          href="/"
+          aria-label="ninthinning.email"
+          className="text-[15px] text-[#f7f5ef] transition hover:opacity-90"
+        >
+          <BrandLockup glyphSize={26} dark />
+        </Link>
+        <Link
+          href="/dashboard"
+          className="text-sm font-medium text-[#a8a299] transition hover:text-[#f7f5ef]"
+        >
+          Dashboard
+        </Link>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-6 pb-24 pt-4">
+        <div className="flex items-center justify-between">
+          {team?.abbr ? (
+            <span
+              className="inline-block rounded px-2.5 py-1 text-[11px] font-bold uppercase tracking-wider text-white"
+              style={{ backgroundColor: teamColor }}
+            >
+              {team.abbr}
+            </span>
+          ) : (
+            <span />
+          )}
+          <span className="text-xs uppercase tracking-wider text-[#a8a299]">
+            {displayDate}
+          </span>
+        </div>
+
+        <h1 className="mt-4 text-3xl font-bold tracking-tight text-[#f7f5ef] sm:text-4xl">
+          {teamName} highlights
+        </h1>
+        {series && (
+          <p className="mt-2 text-sm font-semibold uppercase tracking-wide text-[#a8a299]">
+            {series}
+          </p>
+        )}
+        <p className="mt-2 text-[#a8a299]">
+          Your spoiler-free game recap — no score, just the plays.
+        </p>
+
+        <div className="mt-8">
+          {isMp4 ? (
+            <>
+              <div
+                className="overflow-hidden rounded-xl border"
+                style={{ borderColor: teamColor }}
+              >
+                <div
+                  className="h-1.5"
+                  style={{ backgroundColor: teamColor }}
+                  aria-hidden="true"
+                />
+                {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+                <video
+                  controls
+                  playsInline
+                  preload="metadata"
+                  className="block aspect-video w-full bg-black"
+                >
+                  <source src={highlightUrl} type="video/mp4" />
+                </video>
+              </div>
+              <p className="mt-3 text-center text-xs text-[#a8a299]">
+                Trouble playing?{" "}
+                <a
+                  href={highlightUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline transition hover:text-[#f7f5ef]"
+                >
+                  Open the video directly &#8599;
+                </a>
+              </p>
+            </>
+          ) : highlightUrl ? (
+            <a
+              href={highlightUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block rounded-xl px-6 py-5 text-center text-base font-semibold text-white transition hover:opacity-90"
+              style={{ backgroundColor: teamColor }}
+            >
+              Watch the recap &#9654;
+            </a>
+          ) : (
+            <div className="rounded-xl border border-[#1f3a2c] bg-[#0f2a1f]/40 p-8 text-center">
+              <p className="font-semibold text-[#f7f5ef]">
+                The highlight reel isn&apos;t posted yet.
+              </p>
+              <p className="mt-2 text-sm text-[#a8a299]">
+                MLB usually publishes recaps within a few hours of the final
+                out. Check back a little later.
+              </p>
+              <a
+                href="https://www.mlb.com/video"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-4 inline-block text-sm font-semibold text-[#7fb295] underline transition hover:text-[#f7f5ef]"
+              >
+                Browse recaps on MLB.com &#8599;
+              </a>
+            </div>
+          )}
+        </div>
+
+        <section className="mt-12 border-t border-[#1f3a2c] pt-8">
+          <h2 className="text-xs font-bold uppercase tracking-wider text-[#71717a]">
+            What&apos;s next
+          </h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <NextStepCard
+              href="/dashboard"
+              title="Manage your teams &rarr;"
+              body="Follow another team or update your email preferences."
+            />
+            {tipUrl && (
+              <NextStepCard
+                href={tipUrl}
+                external
+                title="Tip the developer &#9829;"
+                body="Tips keep the servers running and the recaps free."
+              />
+            )}
+          </div>
+        </section>
+
+        <p className="mt-12 text-xs leading-relaxed text-[#71717a]">
+          Ninth Inning Email is not affiliated with, endorsed by, or sponsored
+          by MLB or any MLB club. Highlight video courtesy of MLB.com.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/app/highlights/[gamePk]/view-tracker.js
+++ b/app/highlights/[gamePk]/view-tracker.js
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+import { track } from "@/lib/analytics";
+
+// Fires the highlights_page_viewed PostHog event once on mount. The page
+// itself is a server component, so this mirrors the signup-tracker pattern:
+// a tiny client island whose only job is the analytics call.
+export default function HighlightsViewTracker({ gamePk, teamId }) {
+  useEffect(() => {
+    track("highlights_page_viewed", { game_pk: gamePk, team_id: teamId });
+  }, [gamePk, teamId]);
+
+  return null;
+}

--- a/lib/__snapshots__/email-template.test.js.snap
+++ b/lib/__snapshots__/email-template.test.js.snap
@@ -48,7 +48,7 @@ exports[`buildMultiGameEmailHtml (#27) > matches the multi-game email snapshot 1
         <p style="margin:12px 0 0 0;font-size:13px;font-weight:600;letter-spacing:0.04em;color:#71717a;text-transform:uppercase;">vs Red Sox &mdash; Game 2 of 3</p>
         <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
           <tr><td align="center" style="padding-top:16px;">
-            <a href="https://www.mlb.com/video/yankees-recap?utm_source=ninthinning&utm_medium=email&utm_campaign=recap" style="display:inline-block;background-color:#003087;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.3px;">Watch Highlights &#9654;</a>
+            <a href="https://ninthinning.email/highlights/778001?utm_source=ninthinning&utm_medium=email&utm_campaign=recap" style="display:inline-block;background-color:#003087;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.3px;">Watch Highlights &#9654;</a>
           </td></tr>
           <tr><td align="center" style="padding-top:8px;font-size:12px;color:#a1a1aa;">
             Video: <a href="https://www.mlb.com" style="color:#a1a1aa;">MLB.com</a>
@@ -77,7 +77,7 @@ exports[`buildMultiGameEmailHtml (#27) > matches the multi-game email snapshot 1
         <p style="margin:12px 0 0 0;font-size:13px;font-weight:600;letter-spacing:0.04em;color:#71717a;text-transform:uppercase;">@ Giants &mdash; Game 1 of 3</p>
         <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
           <tr><td align="center" style="padding-top:16px;">
-            <a href="https://www.mlb.com/video/dodgers-recap?utm_source=ninthinning&utm_medium=email&utm_campaign=recap" style="display:inline-block;background-color:#005A9C;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.3px;">Watch Highlights &#9654;</a>
+            <a href="https://ninthinning.email/highlights/778002?utm_source=ninthinning&utm_medium=email&utm_campaign=recap" style="display:inline-block;background-color:#005A9C;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;padding:12px 32px;border-radius:8px;letter-spacing:0.3px;">Watch Highlights &#9654;</a>
           </td></tr>
           <tr><td align="center" style="padding-top:8px;font-size:12px;color:#a1a1aa;">
             Video: <a href="https://www.mlb.com" style="color:#a1a1aa;">MLB.com</a>

--- a/lib/cron-jobs.integration.test.js
+++ b/lib/cron-jobs.integration.test.js
@@ -507,10 +507,11 @@ describe("runMainCron — batched multi-game email (#27)", () => {
     );
     expect(dualFanCalls).toHaveLength(1);
 
-    // That one email's body carries both games' highlights and team names.
+    // That one email's body carries a branded recap CTA per game (#77,
+    // keyed on game_pk) and both team names.
     const [, subject, html] = dualFanCalls[0];
-    expect(html).toContain("mlb.com/video/yankees-recap");
-    expect(html).toContain("mlb.com/video/dodgers-recap");
+    expect(html).toContain(`/highlights/${GAME_A}`);
+    expect(html).toContain(`/highlights/${GAME_B}`);
     expect(html).toContain("New York Yankees");
     expect(html).toContain("Los Angeles Dodgers");
     expect(subject).toMatch(/^Your .* highlights — /);

--- a/lib/cron-jobs.js
+++ b/lib/cron-jobs.js
@@ -522,7 +522,11 @@ export async function runMainCron({
               userId,
               renderGames[0].game.gameDate,
               renderGames[0].standing,
-              { ...(templateOpts || {}), seriesContext: renderGames[0].seriesContext }
+              {
+                ...(templateOpts || {}),
+                seriesContext: renderGames[0].seriesContext,
+                gamePk: renderGames[0].game.gamePk,
+              }
             )
           : buildMultiGameEmailHtml(
               renderGames.map((rg) => ({
@@ -531,6 +535,7 @@ export async function runMainCron({
                 gameDate: rg.game.gameDate,
                 standing: rg.standing,
                 seriesContext: rg.seriesContext,
+                gamePk: rg.game.gamePk,
               })),
               userId,
               templateOpts || undefined

--- a/lib/email-template.js
+++ b/lib/email-template.js
@@ -22,9 +22,9 @@ function getSiteUrl(override) {
   );
 }
 
-// Append our standard recap-email UTM params to a CTA URL so MLB.com
-// clickthroughs (and, eventually, our own highlights landing page) show up
-// in analytics with consistent attribution. Existing params on the input URL
+// Append our standard recap-email UTM params to a CTA URL so clickthroughs to
+// our highlights landing page (#77) show up in analytics with consistent
+// attribution. Existing params on the input URL
 // win — we never overwrite a value the upstream URL already carries. If the
 // URL fails to parse we return it unchanged rather than breaking the email.
 export function appendUtmParams(url, params = RECAP_CTA_UTM) {
@@ -47,6 +47,19 @@ const RECAP_CTA_UTM = {
   utm_medium: "email",
   utm_campaign: "recap",
 };
+
+// The recap "Watch Highlights" CTA points at our own branded interstitial —
+// /highlights/{gamePk} (#77) — rather than straight to MLB.com, so the
+// highest-intent click in the funnel lands on a page we own and can
+// instrument. UTM params are appended either way. Falls back to the raw
+// highlight URL when no gamePk is available (the interstitial is keyed on it).
+function recapCtaUrl({ gamePk, highlightUrl, siteUrl }) {
+  const target =
+    Number.isInteger(gamePk) && gamePk > 0
+      ? `${siteUrl}/highlights/${gamePk}`
+      : highlightUrl;
+  return appendUtmParams(target);
+}
 
 export function buildWelcomeEmailHtml(userId, { siteUrl: siteUrlOverride, tipUrl: tipUrlOverride } = {}) {
   const siteUrl = getSiteUrl(siteUrlOverride);
@@ -306,7 +319,12 @@ export function buildEmailHtml(
   userId,
   gameDate,
   standing = null,
-  { siteUrl: siteUrlOverride, tipUrl: tipUrlOverride, seriesContext = null } = {}
+  {
+    siteUrl: siteUrlOverride,
+    tipUrl: tipUrlOverride,
+    seriesContext = null,
+    gamePk = null,
+  } = {}
 ) {
   const siteUrl = getSiteUrl(siteUrlOverride);
   const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${userId}`;
@@ -318,7 +336,7 @@ export function buildEmailHtml(
   const displayDate = formatDisplayDate(gameDate);
   const standingsHtml = renderStandingsStrip(standing, teamColor);
   const seriesContextHtml = renderSeriesContextLine(seriesContext);
-  const ctaUrl = appendUtmParams(highlightUrl);
+  const ctaUrl = recapCtaUrl({ gamePk, highlightUrl, siteUrl });
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -427,13 +445,17 @@ export function buildEmailHtml(
 // One game card for the multi-game recap email (#27). Mirrors the single-game
 // layout — team color bar, team chip, spoiler-safe series line, Watch CTA,
 // standings strip — compressed into a nested card so several stack cleanly.
-// `game` is { team, highlightUrl, gameDate, standing, seriesContext }.
-function renderGameCard({ team, highlightUrl, gameDate, standing = null, seriesContext = null }) {
+// `game` is { team, highlightUrl, gameDate, standing, seriesContext, gamePk }.
+// `siteUrl` is threaded through so the CTA can target /highlights/{gamePk} (#77).
+function renderGameCard(
+  { team, highlightUrl, gameDate, standing = null, seriesContext = null, gamePk = null },
+  siteUrl
+) {
   const teamName = team?.name || "Your team";
   const teamColor = team?.color || "#2563eb";
   const teamAbbr = team?.abbr || "";
   const displayDate = formatDisplayDate(gameDate);
-  const ctaUrl = appendUtmParams(highlightUrl);
+  const ctaUrl = recapCtaUrl({ gamePk, highlightUrl, siteUrl });
   const series = seriesContextLine(seriesContext);
   const parts = standingsParts(standing);
 
@@ -481,9 +503,9 @@ function renderGameCard({ team, highlightUrl, gameDate, standing = null, seriesC
 // games finished in the same cron window, runMainCron batches them into one
 // email instead of sending one per game. The single-game path still uses
 // buildEmailHtml — this is only reached for 2+ games. `games` is a non-empty
-// array of { team, highlightUrl, gameDate, standing, seriesContext }, one per
-// game, rendered as a stack of cards. The accent bar is brand green rather
-// than a team color, since the email spans multiple teams.
+// array of { team, highlightUrl, gameDate, standing, seriesContext, gamePk },
+// one per game, rendered as a stack of cards. The accent bar is brand green
+// rather than a team color, since the email spans multiple teams.
 export function buildMultiGameEmailHtml(
   games,
   userId,
@@ -496,7 +518,7 @@ export function buildMultiGameEmailHtml(
   const accent = BRAND_GREEN;
   const sortedDates = games.map((g) => g.gameDate).sort();
   const displayDate = formatDisplayDate(sortedDates[sortedDates.length - 1]);
-  const cardsHtml = games.map((g) => renderGameCard(g)).join("");
+  const cardsHtml = games.map((g) => renderGameCard(g, siteUrl)).join("");
 
   return `<!DOCTYPE html>
 <html lang="en">

--- a/lib/email-template.test.js
+++ b/lib/email-template.test.js
@@ -33,15 +33,29 @@ describe("buildEmailHtml", () => {
     expect(html).toContain("#003087");
   });
 
-  it("links the watch button to the highlight URL with recap UTM params (#93)", () => {
+  it("points the watch CTA at the branded /highlights/{gamePk} page (#77)", () => {
+    process.env.SITE_URL = "https://ninthinning.email";
+    const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE, null, {
+      gamePk: 776543,
+    });
+    expect(html).toContain(
+      "https://ninthinning.email/highlights/776543?utm_source=ninthinning"
+    );
+    expect(html).toContain("utm_medium=email");
+    expect(html).toContain("utm_campaign=recap");
+    // The raw MLB video URL is no longer in the email — the click routes
+    // through our own page, which fetches the highlight itself.
+    expect(html).not.toContain(HIGHLIGHT_URL);
+  });
+
+  it("falls back to the raw highlight URL when no gamePk is given (#93)", () => {
     const html = buildEmailHtml(TEAM, HIGHLIGHT_URL, USER_ID, GAME_DATE);
     expect(html).toContain(HIGHLIGHT_URL);
     expect(html).toContain("utm_source=ninthinning");
-    expect(html).toContain("utm_medium=email");
-    expect(html).toContain("utm_campaign=recap");
+    expect(html).not.toContain("/highlights/");
   });
 
-  it("preserves any pre-existing UTM params on the highlight URL", () => {
+  it("preserves any pre-existing UTM params on the fallback highlight URL", () => {
     const url = "https://www.mlb.com/video/abc?utm_source=mlb";
     const html = buildEmailHtml(TEAM, url, USER_ID, GAME_DATE);
     expect(html).toContain("utm_source=mlb");
@@ -321,6 +335,7 @@ describe("buildMultiGameEmailHtml (#27)", () => {
     {
       team: YANKEES,
       highlightUrl: "https://www.mlb.com/video/yankees-recap",
+      gamePk: 778001,
       gameDate: "2026-05-18",
       standing: {
         divisionName: "AL East",
@@ -341,6 +356,7 @@ describe("buildMultiGameEmailHtml (#27)", () => {
     {
       team: DODGERS,
       highlightUrl: "https://www.mlb.com/video/dodgers-recap",
+      gamePk: 778002,
       gameDate: "2026-05-18",
       standing: null,
       seriesContext: {
@@ -368,12 +384,13 @@ describe("buildMultiGameEmailHtml (#27)", () => {
     expect(buildMultiGameEmailHtml(GAMES, USER_ID)).toMatchSnapshot();
   });
 
-  it("renders one card per game with both teams and both highlight URLs", () => {
+  it("renders one card per game with both teams and a per-game recap CTA", () => {
     const html = buildMultiGameEmailHtml(GAMES, USER_ID);
     expect(html).toContain("New York Yankees");
     expect(html).toContain("Los Angeles Dodgers");
-    expect(html).toContain("https://www.mlb.com/video/yankees-recap");
-    expect(html).toContain("https://www.mlb.com/video/dodgers-recap");
+    // Each card's CTA points at our branded interstitial, keyed on game_pk (#77).
+    expect(html).toContain("/highlights/778001");
+    expect(html).toContain("/highlights/778002");
     // One Watch Highlights CTA per game card.
     expect(html.match(/Watch Highlights/g)).toHaveLength(2);
   });
@@ -386,8 +403,8 @@ describe("buildMultiGameEmailHtml (#27)", () => {
 
   it("appends recap UTM params to every highlight CTA", () => {
     const html = buildMultiGameEmailHtml(GAMES, USER_ID);
-    expect(html).toContain("yankees-recap?utm_source=ninthinning");
-    expect(html).toContain("dodgers-recap?utm_source=ninthinning");
+    expect(html).toContain("/highlights/778001?utm_source=ninthinning");
+    expect(html).toContain("/highlights/778002?utm_source=ninthinning");
   });
 
   it("carries exactly one unsubscribe and one pause link with the user token", () => {

--- a/lib/resend-recap.js
+++ b/lib/resend-recap.js
@@ -110,7 +110,9 @@ export async function resendLatestRecap({
   const team = TEAMS_BY_ID[teamId];
   const teamName = team?.name || `Team ${teamId}`;
   const subject = `[TEST] ${teamName} Highlights — ${formatDisplayDate(gameDate)}`;
-  const html = buildEmailHtml(team, highlightUrl, adminUserId, gameDate, standing);
+  const html = buildEmailHtml(team, highlightUrl, adminUserId, gameDate, standing, {
+    gamePk,
+  });
 
   await sendImpl(adminEmail, subject, html);
 


### PR DESCRIPTION
## Summary

Closes #77. The recap email's "Watch Highlights" CTA no longer links straight to MLB.com — it routes through a branded interstitial on `ninthinning.email` that wraps the highlight in our chrome, so the highest-intent click in the funnel lands on a page we own and can instrument.

- **New page** `app/highlights/[gamePk]/page.js` — public, no-auth, spoiler-free. Reads `mlb_game_cache` keyed on `game_pk` (unknown/non-numeric → `notFound()`); makes one live `fetchGameContent` retry if the cached `highlight_url` is null. Embeds a native `<video controls preload="metadata">` for direct `.mp4` highlights, branded "Watch the recap" handoff for non-mp4, and a "not posted yet" state when no highlight exists — never a broken player. Shows a best-effort spoiler-safe opponent line, "what's next" CTAs, and the non-affiliation disclaimer.
- **Email CTA rewrite** — `recapCtaUrl()` in `lib/email-template.js` builds `{SITE_URL}/highlights/{gamePk}` (with recap UTM params) for both `buildEmailHtml` and the multi-game `renderGameCard`; `gamePk` threaded in from `lib/cron-jobs.js` and `lib/resend-recap.js`, with a fallback to the raw highlight URL when no `gamePk` is available.
- **Analytics** — `highlights_page_viewed` fires from a `view-tracker.js` client island (mirrors the `signup-tracker` pattern).
- Tests/snapshot and `CLAUDE.md` updated.

### Design note

`extractHighlightUrl` already yields direct `.mp4` CDN URLs (which the email links to today anyway), so the page embeds them in a native `<video>` rather than an MLB player embed — same content access, better UX, with the non-affiliation disclaimer + MLB attribution kept on the page. Per-game pages are `robots: noindex` and excluded from the sitemap.

## Test plan

- [x] `npm run build` passes — `/highlights/[gamePk]` compiles as a dynamic route
- [x] Full test suite passes (195 tests), including updated email-template / integration / admin-action coverage + regenerated snapshot
- [ ] Manual: open `/highlights/{gamePk}` for a real recent game — verify the video plays, the opponent line shows no score, and the "what's next" CTAs work *(could not run locally — this environment has no Supabase credentials, so the dev server can't boot past `middleware.js`)*
- [ ] Manual: click the "Watch Highlights" CTA in a real recap email and confirm it lands on the branded page
- [ ] Verify `highlights_page_viewed` appears in PostHog

https://claude.ai/code/session_01MRDGtTy7BQTiMv1uk3N8NQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRDGtTy7BQTiMv1uk3N8NQ)_