### PR TITLE
Add highlight history list to /dashboard (#90)

### DIFF
--- a/app/dashboard/highlights/page.js
+++ b/app/dashboard/highlights/page.js
@@ -3,7 +3,12 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase-server";
 import { TEAMS_BY_ID } from "@/lib/teams";
 import { formatDisplayDate } from "@/lib/mlb";
+import { buildHighlightHistory } from "@/lib/highlight-history";
 import { BrandLockup } from "@/components/brand";
+
+// How many past recaps to list. mlb_sent_notifications holds one row per
+// game we emailed the user about, so this is a hard cap on the page length.
+const MAX_HISTORY = 50;
 
 export default async function HighlightsPage() {
   const supabase = await createClient();
@@ -18,23 +23,32 @@ export default async function HighlightsPage() {
     .select("team_id")
     .eq("user_id", user.id);
 
-  const followedTeamIds = (userTeams || []).map((r) => r.team_id);
+  const followedCount = (userTeams || []).length;
 
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - 14);
-  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  // Source of truth is the recaps we actually sent (mlb_sent_notifications),
+  // not every game the followed teams played — so a recap still shows here
+  // even after the user unfollows that team. game_pk = 0 is the welcome
+  // sentinel (#26); exclude it at the query so it never counts toward MAX_HISTORY.
+  const { data: sentRows } = await supabase
+    .from("mlb_sent_notifications")
+    .select("game_pk, sent_at")
+    .eq("user_id", user.id)
+    .neq("game_pk", 0)
+    .order("sent_at", { ascending: false })
+    .limit(MAX_HISTORY);
 
-  let highlights = [];
-  if (followedTeamIds.length > 0) {
-    const { data } = await supabase
+  // mlb_sent_notifications has no FK to mlb_game_cache, so PostgREST can't
+  // embed the join — fetch the matching cache rows and merge in JS.
+  let history = [];
+  if (sentRows && sentRows.length > 0) {
+    const { data: gameCacheRows } = await supabase
       .from("mlb_game_cache")
       .select("game_pk, team_id, game_date, highlight_url")
-      .in("team_id", followedTeamIds)
-      .not("highlight_url", "is", null)
-      .gte("game_date", cutoffStr)
-      .order("game_date", { ascending: false })
-      .limit(50);
-    highlights = data || [];
+      .in(
+        "game_pk",
+        sentRows.map((r) => r.game_pk),
+      );
+    history = buildHighlightHistory(sentRows, gameCacheRows);
   }
 
   return (
@@ -60,54 +74,54 @@ export default async function HighlightsPage() {
           Highlights
         </h1>
         <p className="mt-2 text-[#a8a299]">
-          Recent game recaps for your followed teams (last 14 days).
+          The spoiler-free recaps we&apos;ve emailed you — re-watch any of them
+          here.
         </p>
 
         <div className="mt-10">
-          {followedTeamIds.length === 0 ? (
+          {followedCount === 0 ? (
             <EmptyState
               title="No teams followed yet"
               body="Pick a team and we'll start dropping recaps here as soon as they play."
               cta={{ href: "/dashboard", label: "Choose your teams" }}
             />
-          ) : highlights.length === 0 ? (
+          ) : history.length === 0 ? (
             <EmptyState
               title="No recaps yet"
-              body="Recaps appear here within a few hours of the final out. Check back after your team's next game."
+              body="Your first recap will land after your team's next game finishes."
             />
           ) : (
-            <div className="space-y-3">
-              {highlights.map((game) => {
-                const team = TEAMS_BY_ID[game.team_id];
+            <ul className="space-y-3">
+              {history.map((game) => {
+                const team = TEAMS_BY_ID[game.teamId];
                 return (
-                  <a
-                    key={game.game_pk}
-                    href={game.highlight_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center justify-between rounded-lg border border-[#1f3a2c] bg-[#0f2a1f]/40 px-5 py-4 transition hover:border-[#4a7a5b] hover:bg-[#0f2a1f]/60"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div
-                        className="w-1 self-stretch rounded-full"
-                        style={{ backgroundColor: team?.color || "#3f6e57" }}
-                      />
-                      <div>
-                        <div className="text-sm font-medium text-[#f7f5ef]">
-                          {team?.name || `Team ${game.team_id}`}
-                        </div>
-                        <div className="mt-0.5 text-xs text-[#a8a299]">
-                          {formatDisplayDate(game.game_date)}
+                  <li key={game.gamePk}>
+                    <Link
+                      href={`/highlights/${game.gamePk}`}
+                      className="group flex items-center justify-between rounded-lg border border-[#1f3a2c] bg-[#0f2a1f]/40 px-5 py-4 transition hover:border-[#4a7a5b] hover:bg-[#0f2a1f]/60"
+                    >
+                      <div className="flex items-center gap-4">
+                        <div
+                          className="w-1 self-stretch rounded-full"
+                          style={{ backgroundColor: team?.color || "#3f6e57" }}
+                        />
+                        <div>
+                          <div className="text-sm font-medium text-[#f7f5ef]">
+                            {team?.name || `Team ${game.teamId}`}
+                          </div>
+                          <div className="mt-0.5 text-xs text-[#a8a299]">
+                            {formatDisplayDate(game.gameDate)}
+                          </div>
                         </div>
                       </div>
-                    </div>
-                    <span className="shrink-0 text-xs font-medium text-[#a8a299] transition group-hover:text-[#f7f5ef]">
-                      Watch recap →
-                    </span>
-                  </a>
+                      <span className="shrink-0 text-xs font-medium text-[#a8a299] transition group-hover:text-[#f7f5ef]">
+                        Watch recap →
+                      </span>
+                    </Link>
+                  </li>
                 );
               })}
-            </div>
+            </ul>
           )}
         </div>
       </main>

--- a/lib/highlight-history.js
+++ b/lib/highlight-history.js
@@ -1,0 +1,41 @@
+// Highlight-history helpers (#90).
+//
+// The /dashboard/highlights page shows a user the recaps we have actually
+// emailed them — sourced from mlb_sent_notifications, not "every game the
+// teams you follow played." buildHighlightHistory joins those send records
+// against the cached game metadata in mlb_game_cache so the page can render
+// one row per recap that links to the branded highlights page.
+
+// game_pk = 0 is the welcome-email sentinel (#26), not a real game.
+export const WELCOME_SENTINEL_GAME_PK = 0;
+
+// Joins sent-notification rows with cached game metadata.
+//
+// sentRows:      [{ game_pk, sent_at }, ...]      from mlb_sent_notifications
+// gameCacheRows: [{ game_pk, team_id, game_date, highlight_url }, ...]
+//
+// Returns one item per real recap, newest-sent first. A send is dropped when
+// it is the welcome sentinel, or when no cached game row exists for it — the
+// branded highlights page notFound()s on an unknown game_pk, so such a row
+// could not link anywhere useful.
+export function buildHighlightHistory(sentRows, gameCacheRows) {
+  const cacheByPk = new Map(
+    (gameCacheRows || []).map((g) => [g.game_pk, g]),
+  );
+
+  return (sentRows || [])
+    .filter((row) => row.game_pk !== WELCOME_SENTINEL_GAME_PK)
+    .map((row) => {
+      const game = cacheByPk.get(row.game_pk);
+      if (!game) return null;
+      return {
+        gamePk: row.game_pk,
+        teamId: game.team_id,
+        gameDate: game.game_date,
+        highlightUrl: game.highlight_url ?? null,
+        sentAt: row.sent_at,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => Date.parse(b.sentAt) - Date.parse(a.sentAt));
+}

--- a/lib/highlight-history.test.js
+++ b/lib/highlight-history.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  WELCOME_SENTINEL_GAME_PK,
+  buildHighlightHistory,
+} from "./highlight-history";
+
+const game = (overrides) => ({
+  game_pk: 100,
+  team_id: 147,
+  game_date: "2026-05-20",
+  highlight_url: "https://www.mlb.com/video/clip-100",
+  ...overrides,
+});
+
+describe("buildHighlightHistory", () => {
+  it("returns an empty list when there are no sent notifications", () => {
+    expect(buildHighlightHistory([], [game()])).toEqual([]);
+    expect(buildHighlightHistory(null, null)).toEqual([]);
+    expect(buildHighlightHistory(undefined, undefined)).toEqual([]);
+  });
+
+  it("joins a single send against its cached game metadata", () => {
+    const out = buildHighlightHistory(
+      [{ game_pk: 100, sent_at: "2026-05-21T13:00:00Z" }],
+      [game()],
+    );
+    expect(out).toEqual([
+      {
+        gamePk: 100,
+        teamId: 147,
+        gameDate: "2026-05-20",
+        highlightUrl: "https://www.mlb.com/video/clip-100",
+        sentAt: "2026-05-21T13:00:00Z",
+      },
+    ]);
+  });
+
+  it("orders many sends newest-sent first regardless of input order", () => {
+    const out = buildHighlightHistory(
+      [
+        { game_pk: 100, sent_at: "2026-05-19T13:00:00Z" },
+        { game_pk: 102, sent_at: "2026-05-21T13:00:00Z" },
+        { game_pk: 101, sent_at: "2026-05-20T13:00:00Z" },
+      ],
+      [
+        game({ game_pk: 100 }),
+        game({ game_pk: 101 }),
+        game({ game_pk: 102 }),
+      ],
+    );
+    expect(out.map((h) => h.gamePk)).toEqual([102, 101, 100]);
+  });
+
+  it("drops the welcome-email sentinel send", () => {
+    const out = buildHighlightHistory(
+      [
+        { game_pk: WELCOME_SENTINEL_GAME_PK, sent_at: "2026-05-18T13:00:00Z" },
+        { game_pk: 100, sent_at: "2026-05-21T13:00:00Z" },
+      ],
+      [game({ game_pk: 100 })],
+    );
+    expect(out.map((h) => h.gamePk)).toEqual([100]);
+  });
+
+  it("drops a send with no cached game row (branded page would notFound)", () => {
+    const out = buildHighlightHistory(
+      [
+        { game_pk: 100, sent_at: "2026-05-21T13:00:00Z" },
+        { game_pk: 999, sent_at: "2026-05-20T13:00:00Z" },
+      ],
+      [game({ game_pk: 100 })],
+    );
+    expect(out.map((h) => h.gamePk)).toEqual([100]);
+  });
+
+  it("keeps a send whose cached game has no highlight_url yet", () => {
+    const out = buildHighlightHistory(
+      [{ game_pk: 100, sent_at: "2026-05-21T13:00:00Z" }],
+      [game({ highlight_url: null })],
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].highlightUrl).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Brings the `/dashboard/highlights` page in line with #90. The page previously listed *every game the followed teams played* (sourced from `mlb_game_cache`) and linked straight to MLB.com. Issue #90 asks for the recaps we **actually emailed** the user, linking to the branded highlights page (#77).

- **`lib/highlight-history.js`** — new `buildHighlightHistory()` helper that joins `mlb_sent_notifications` against cached game metadata, drops the welcome sentinel (`game_pk = 0`) and sends with no cached game row, and orders newest-sent first.
- **`app/dashboard/highlights/page.js`** — now queries `mlb_sent_notifications` (so a recap still shows after the user unfollows that team), links each row to `/highlights/{gamePk}` instead of the raw MLB.com URL, and uses the issue's empty-state copy ("Your first recap will land after your team's next game finishes.").
- **`lib/highlight-history.test.js`** — 6 unit tests: 0 / 1 / many sent notifications, sentinel exclusion, missing cache rows, ordering, and a null `highlight_url`.

Stays spoiler-free (date + team only, no score/win-loss/play-by-play). The list is server-rendered with a fixed layout, so no layout shift.

## Scope note

#90's Scope mentions an "opponent" line, but `mlb_game_cache` doesn't store the opponent — adding it would need a schema + cron change, and per-row live `fetchSchedule` calls would be too costly for a 50-item list. Omitted here, consistent with the branded highlights page's own best-effort/omit-on-failure stance for opponent context. The hard acceptance criteria (renders for 0/1/many sent notifications, no spoilers, no layout shift) are all met.

## Test plan

- [x] `npx vitest run` — full suite green (19 files, 201 tests)
- [x] `next build` succeeds; `/dashboard/highlights` compiles
- [ ] Manual: user with 0 followed teams sees the "Choose your teams" CTA
- [ ] Manual: user with teams but 0 sent recaps sees the "No recaps yet" empty state
- [ ] Manual: user with sent recaps sees the list, each row links to `/highlights/{gamePk}`

Closes #90

https://claude.ai/code/session_01QJh41UaDv8JS41p6dAvouL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJh41UaDv8JS41p6dAvouL)_