### PR TITLE
Add GitHub Actions backup cron, gated on Cloudflare cron health

### DIFF
--- a/.github/workflows/cron-backup.yml
+++ b/.github/workflows/cron-backup.yml
@@ -1,0 +1,39 @@
+name: Cron backup
+
+# Standby backstop for the Cloudflare Cron Triggers (see CLAUDE.md and
+# INCIDENT.md — added after the 2026-05-22 Cloudflare cron outage).
+#
+# Cloudflare's Cron Triggers stay the PRIMARY scheduler. This workflow hits the
+# cron HTTP routes every 15 min with ?backup=1; each route checks mlb_cron_runs
+# first and returns "Backup skipped" while Cloudflare's cron is healthy, so it
+# only does real work during a Cloudflare cron outage.
+#
+# Requires the CRON_SECRET repository secret (Settings > Secrets and variables
+# > Actions). GitHub-scheduled runs can be delayed several minutes under load —
+# fine for a backstop, given the cron's generous wake window.
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  backup-cron:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Main cron (no-op unless Cloudflare cron is stale)
+        run: |
+          curl -fsS --retry 3 --retry-delay 5 --max-time 70 \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            -w '\nHTTP %{http_code}\n' \
+            "https://ninthinning.email/api/cron?backup=1"
+
+      - name: Daily scheduler (no-op unless scheduler is stale)
+        if: ${{ !cancelled() }}
+        run: |
+          curl -fsS --retry 3 --retry-delay 5 --max-time 40 \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            -w '\nHTTP %{http_code}\n' \
+            "https://ninthinning.email/api/cron/schedule?backup=1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,19 @@ Failure modes worth knowing:
 
 `mlb_cron_runs` statuses to expect from this stack: `running`, `success`, `partial`, `failure`, `paused`, `no_subscribers`, `no_new_highlights`, `skipped_no_wake`, `dry_run` (main cron) and `schedule_running`, `schedule_built`, `schedule_partial`, `schedule_failure` (scheduler). `dry_run` (#180) marks a `runMainCron({ dryRun: true })` invocation — the full pipeline ran but the Brevo send and `mlb_sent_notifications` insert were skipped; treat such rows as diagnostic, not real sends. Per postmortem #103 / #104, every `*/15` tick now writes exactly one row — silence is treated as a failure mode, so an empty `mlb_cron_runs` hour means the cron itself isn't running and should page, not "no game in window."
 
+### GitHub Actions backup cron
+
+Cloudflare Cron Triggers are the **primary** scheduler. `.github/workflows/cron-backup.yml` is a standby backstop, added after the 2026-05-22 Cloudflare cron outage (see `INCIDENT.md`) when Cloudflare silently stopped dispatching `scheduled()` events to the worker for hours despite registered triggers and a valid handler.
+
+Every 15 min the workflow calls `/api/cron?backup=1` and `/api/cron/schedule?backup=1`. The `?backup=1` flag makes each route call `cronRanRecently()` (`lib/cron-backup.js`) against `mlb_cron_runs` **before** doing any work:
+
+- `/api/cron` skips if any row landed in the last 25 min (Cloudflare's `*/15` cron is alive).
+- `/api/cron/schedule` skips if a `schedule_*` row landed in the last 25h (Cloudflare ran today's scheduler).
+
+So while Cloudflare's cron is healthy the backup is a pure no-op — one Supabase read, no double-execution. It only runs the real job once Cloudflare's cron has gone silent. Because the backup's own runs also write `mlb_cron_runs` rows, during a Cloudflare outage it self-paces to roughly every 30 min — well within the asymmetric wake window, so no recap is missed. On a freshness-query error it falls open (runs), same stance as the schedule read. `mlb_sent_notifications` dedup makes any overlap with a recovering Cloudflare cron harmless.
+
+Requires the **`CRON_SECRET`** GitHub Actions repository secret (Settings → Secrets and variables → Actions) — the routes authenticate the same bearer token as manual curl recovery. GitHub-scheduled runs can lag several minutes under load; fine for a backstop. The non-`backup` path of both routes (manual curl, no `?backup=1`) is unchanged and always runs.
+
 ## Break-glass recovery (#110)
 
 When you need to manually kick the cron — e.g. the daily scheduler missed a tick, or a *every-15-min run silently early-returned during a deploy window — the primary recovery path is the **/admin** page, not curl + bearer token.

--- a/app/api/cron/route.js
+++ b/app/api/cron/route.js
@@ -1,8 +1,15 @@
 import { NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase-admin";
 import { runMainCron } from "@/lib/cron-jobs";
+import { cronRanRecently } from "@/lib/cron-backup";
 
 export const maxDuration = 60;
+
+// The GitHub Actions backup cron calls this with ?backup=1. It only runs the
+// real job when Cloudflare's own cron looks dead — no mlb_cron_runs row in the
+// last BACKUP_STALE_MS. That keeps Cloudflare's scheduler primary; while it is
+// healthy the backup is a no-op. See .github/workflows/cron-backup.yml.
+const BACKUP_STALE_MS = 25 * 60 * 1000;
 
 export async function GET(request) {
   const authHeader = request.headers.get("authorization");
@@ -11,6 +18,15 @@ export async function GET(request) {
   }
 
   const supabase = createAdminClient();
+
+  if (new URL(request.url).searchParams.get("backup") === "1") {
+    if (await cronRanRecently(supabase, { maxAgeMs: BACKUP_STALE_MS })) {
+      return NextResponse.json({
+        message: "Backup skipped — Cloudflare cron is healthy",
+      });
+    }
+  }
+
   const { status, body } = await runMainCron({
     supabase,
     emailsPaused: process.env.EMAILS_PAUSED === "true",

--- a/app/api/cron/route.test.js
+++ b/app/api/cron/route.test.js
@@ -34,6 +34,8 @@ function makeSupabaseMock({
   scheduleError = null,
   anyRows = [{ game_pk: 1 }],
   anyError = null,
+  lastRunRows = [],
+  lastRunError = null,
 } = {}) {
   const inserted = [];
   const updates = [];
@@ -50,6 +52,12 @@ function makeSupabaseMock({
       }),
     }),
     mlb_cron_runs: () => ({
+      // Freshness query used by the ?backup=1 gate (cronRanRecently).
+      select: () => ({
+        order: () => ({
+          limit: async () => ({ data: lastRunRows, error: lastRunError }),
+        }),
+      }),
       insert: (row) => {
         inserted.push(row);
         return {
@@ -89,8 +97,11 @@ function makeSupabaseMock({
   return { client, inserted, updates };
 }
 
-function makeRequest({ auth = "Bearer secret" } = {}) {
-  return new Request("https://ninthinning.email/api/cron", {
+function makeRequest({ auth = "Bearer secret", backup = false } = {}) {
+  const url = backup
+    ? "https://ninthinning.email/api/cron?backup=1"
+    : "https://ninthinning.email/api/cron";
+  return new Request(url, {
     headers: auth ? { Authorization: auth } : {},
   });
 }
@@ -287,5 +298,81 @@ describe("GET /api/cron — schedule-aware early return (#76)", () => {
     for (const call of fromMock.mock.calls) {
       expect(call[0]).toBe("mlb_cron_runs");
     }
+  });
+});
+
+describe("GET /api/cron?backup=1 — GitHub Actions backup gate", () => {
+  it("skips without running the cron when Cloudflare's cron ran recently", async () => {
+    const { client, inserted } = makeSupabaseMock({
+      lastRunRows: [
+        { started_at: new Date(Date.now() - 5 * 60 * 1000).toISOString() },
+      ],
+    });
+    createAdminClient.mockReturnValue(client);
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest({ backup: true }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      message: "Backup skipped — Cloudflare cron is healthy",
+    });
+    // runMainCron never ran — startRun would have inserted a row.
+    expect(inserted).toEqual([]);
+  });
+
+  it("runs the cron when the last mlb_cron_runs row is stale", async () => {
+    const { client, inserted } = makeSupabaseMock({
+      lastRunRows: [
+        { started_at: new Date(Date.now() - 40 * 60 * 1000).toISOString() },
+      ],
+    });
+    createAdminClient.mockReturnValue(client);
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest({ backup: true }));
+
+    expect(res.status).toBe(200);
+    // Fell through to runMainCron — heartbeat path writes the running row.
+    expect(inserted).toEqual([{ status: "running" }]);
+  });
+
+  it("runs the cron when there is no prior run row at all", async () => {
+    const { client, inserted } = makeSupabaseMock({ lastRunRows: [] });
+    createAdminClient.mockReturnValue(client);
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest({ backup: true }));
+
+    expect(res.status).toBe(200);
+    expect(inserted).toEqual([{ status: "running" }]);
+  });
+
+  it("falls open and runs the cron when the freshness check errors", async () => {
+    const { client, inserted } = makeSupabaseMock({
+      lastRunRows: null,
+      lastRunError: { message: "boom" },
+    });
+    createAdminClient.mockReturnValue(client);
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest({ backup: true }));
+
+    expect(res.status).toBe(200);
+    expect(inserted).toEqual([{ status: "running" }]);
+  });
+
+  it("ignores the freshness gate for non-backup requests", async () => {
+    // A run just happened, but without ?backup=1 the route runs anyway.
+    const { client, inserted } = makeSupabaseMock({
+      lastRunRows: [{ started_at: new Date().toISOString() }],
+    });
+    createAdminClient.mockReturnValue(client);
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(200);
+    expect(inserted).toEqual([{ status: "running" }]);
   });
 });

--- a/app/api/cron/schedule/route.js
+++ b/app/api/cron/schedule/route.js
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase-admin";
 import { runScheduler } from "@/lib/cron-jobs";
+import { cronRanRecently } from "@/lib/cron-backup";
 
 export const maxDuration = 30;
+
+// The GitHub Actions backup cron calls this with ?backup=1. The scheduler runs
+// once a day, so the backup only runs it when no schedule_* row has landed in
+// the last BACKUP_SCHEDULER_STALE_MS — i.e. Cloudflare missed today's tick.
+const BACKUP_SCHEDULER_STALE_MS = 25 * 60 * 60 * 1000;
 
 export async function GET(request) {
   const authHeader = request.headers.get("authorization");
@@ -11,6 +17,19 @@ export async function GET(request) {
   }
 
   const supabase = createAdminClient();
+
+  if (new URL(request.url).searchParams.get("backup") === "1") {
+    const recent = await cronRanRecently(supabase, {
+      maxAgeMs: BACKUP_SCHEDULER_STALE_MS,
+      statusPrefix: "schedule",
+    });
+    if (recent) {
+      return NextResponse.json({
+        message: "Backup skipped — scheduler ran recently",
+      });
+    }
+  }
+
   const { status, body } = await runScheduler({ supabase });
   return NextResponse.json(body, { status });
 }

--- a/app/api/cron/schedule/route.test.js
+++ b/app/api/cron/schedule/route.test.js
@@ -15,7 +15,12 @@ vi.mock("@/lib/mlb", async () => {
   };
 });
 
-function makeSupabaseMock({ upsertResult = { error: null }, deleteResult = { error: null } } = {}) {
+function makeSupabaseMock({
+  upsertResult = { error: null },
+  deleteResult = { error: null },
+  lastRunRows = [],
+  lastRunError = null,
+} = {}) {
   const insertedRuns = [];
   const upsertCalls = [];
   const deleteCalls = [];
@@ -25,6 +30,14 @@ function makeSupabaseMock({ upsertResult = { error: null }, deleteResult = { err
     from: vi.fn((table) => {
       if (table === "mlb_cron_runs") {
         return {
+          // Freshness query used by the ?backup=1 gate (cronRanRecently).
+          select: vi.fn(() => ({
+            like: () => ({
+              order: () => ({
+                limit: async () => ({ data: lastRunRows, error: lastRunError }),
+              }),
+            }),
+          })),
           insert: vi.fn((row) => {
             insertedRuns.push(row);
             return {
@@ -68,8 +81,11 @@ beforeEach(() => {
   process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role";
 });
 
-function makeRequest({ auth = "Bearer secret" } = {}) {
-  return new Request("https://ninthinning.email/api/cron/schedule", {
+function makeRequest({ auth = "Bearer secret", backup = false } = {}) {
+  const url = backup
+    ? "https://ninthinning.email/api/cron/schedule?backup=1"
+    : "https://ninthinning.email/api/cron/schedule";
+  return new Request(url, {
     headers: auth ? { Authorization: auth } : {},
   });
 }
@@ -147,5 +163,72 @@ describe("GET /api/cron/schedule", () => {
     expect(res.status).toBe(500);
     expect(updates[0]).toMatchObject({ status: "schedule_failure" });
     expect(updates[0].errors_count).toBe(1);
+  });
+});
+
+describe("GET /api/cron/schedule?backup=1 — GitHub Actions backup gate", () => {
+  it("skips without running the scheduler when it ran recently", async () => {
+    const { client, insertedRuns, upsertCalls } = makeSupabaseMock({
+      lastRunRows: [
+        { started_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString() },
+      ],
+    });
+    createAdminClient.mockReturnValue(client);
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest({ backup: true }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      message: "Backup skipped — scheduler ran recently",
+    });
+    // runScheduler never ran.
+    expect(insertedRuns).toEqual([]);
+    expect(upsertCalls).toHaveLength(0);
+    expect(fetchDailySchedule).not.toHaveBeenCalled();
+  });
+
+  it("runs the scheduler when the last schedule_* row is stale", async () => {
+    const { client, insertedRuns, updates } = makeSupabaseMock({
+      lastRunRows: [
+        { started_at: new Date(Date.now() - 30 * 60 * 60 * 1000).toISOString() },
+      ],
+    });
+    createAdminClient.mockReturnValue(client);
+    fetchDailySchedule.mockResolvedValue({ dates: [] });
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest({ backup: true }));
+
+    expect(res.status).toBe(200);
+    expect(insertedRuns).toEqual([{ status: "schedule_running" }]);
+    expect(updates[0]).toMatchObject({ status: "schedule_built" });
+  });
+
+  it("runs the scheduler when there is no prior schedule_* row", async () => {
+    const { client, insertedRuns } = makeSupabaseMock({ lastRunRows: [] });
+    createAdminClient.mockReturnValue(client);
+    fetchDailySchedule.mockResolvedValue({ dates: [] });
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest({ backup: true }));
+
+    expect(res.status).toBe(200);
+    expect(insertedRuns).toEqual([{ status: "schedule_running" }]);
+  });
+
+  it("falls open and runs the scheduler when the freshness check errors", async () => {
+    const { client, insertedRuns } = makeSupabaseMock({
+      lastRunRows: null,
+      lastRunError: { message: "boom" },
+    });
+    createAdminClient.mockReturnValue(client);
+    fetchDailySchedule.mockResolvedValue({ dates: [] });
+
+    const { GET } = await import("./route");
+    const res = await GET(makeRequest({ backup: true }));
+
+    expect(res.status).toBe(200);
+    expect(insertedRuns).toEqual([{ status: "schedule_running" }]);
   });
 });

--- a/lib/cron-backup.js
+++ b/lib/cron-backup.js
@@ -1,0 +1,20 @@
+// Backstop for the Cloudflare Cron Triggers. The GitHub Actions workflow in
+// .github/workflows/cron-backup.yml calls the cron HTTP routes with ?backup=1;
+// those routes use this to decide whether Cloudflare's own cron is still alive
+// and, if so, skip — keeping Cloudflare's scheduler primary and the backup a
+// true no-op. Added after the 2026-05-22 Cloudflare cron outage (INCIDENT.md).
+//
+// `cronRanRecently` returns true when mlb_cron_runs has a row newer than
+// maxAgeMs. Pass statusPrefix to only consider matching statuses (e.g.
+// "schedule" for the daily scheduler). On a read error it returns false —
+// the caller falls open and runs the job, since missing email is worse than
+// a redundant run (mlb_sent_notifications dedup absorbs any overlap anyway).
+export async function cronRanRecently(supabase, { maxAgeMs, statusPrefix } = {}) {
+  let query = supabase.from("mlb_cron_runs").select("started_at");
+  if (statusPrefix) query = query.like("status", `${statusPrefix}%`);
+  const { data, error } = await query
+    .order("started_at", { ascending: false })
+    .limit(1);
+  if (error || !data?.[0]) return false;
+  return Date.now() - new Date(data[0].started_at).getTime() < maxAgeMs;
+}


### PR DESCRIPTION
## Summary

A standby backstop for the Cloudflare Cron Triggers, added after the 2026-05-22 outage where Cloudflare silently stopped dispatching `scheduled()` events to the worker for hours despite registered triggers and a verified-valid handler (see `INCIDENT.md`).

**Cloudflare's cron stays the primary scheduler.** This is backup-only: it does real work *only* when Cloudflare's cron has gone silent.

## How "backup only" works

`.github/workflows/cron-backup.yml` runs every 15 min and calls the cron routes with `?backup=1`. That flag makes each route call `cronRanRecently()` (`lib/cron-backup.js`) against `mlb_cron_runs` **before** doing anything:

- `/api/cron?backup=1` — skips if any row landed in the last **25 min** (Cloudflare's `*/15` cron is alive).
- `/api/cron/schedule?backup=1` — skips if a `schedule_*` row landed in the last **25h** (Cloudflare ran today's scheduler).

While Cloudflare's cron is healthy the backup is a pure no-op — one Supabase read, returns `"Backup skipped …"`, **no double-execution**. It only runs the real job once Cloudflare's cron has actually stopped. On a freshness-query error it falls open (runs) — same stance as the existing schedule read. `mlb_sent_notifications` dedup makes any overlap with a recovering Cloudflare cron harmless.

The non-`backup` path of both routes (manual curl recovery, `/admin`) is **unchanged** — always runs.

## Changes

| File | Change |
|------|--------|
| `lib/cron-backup.js` | New — `cronRanRecently()` freshness check against `mlb_cron_runs` |
| `app/api/cron/route.js` | `?backup=1` gate (25 min staleness) |
| `app/api/cron/schedule/route.js` | `?backup=1` gate (25h staleness, `schedule_*` rows) |
| `.github/workflows/cron-backup.yml` | New — every-15-min standby workflow |
| `app/api/cron/route.test.js` | +5 backup-gate tests |
| `app/api/cron/schedule/route.test.js` | +4 backup-gate tests |
| `CLAUDE.md` | Documents the backup cron |

No schema change.

## Required after merge

Add **`CRON_SECRET`** as a GitHub Actions repository secret (Settings → Secrets and variables → Actions) — the routes authenticate the same bearer token as manual curl recovery. Without it the workflow runs but every call 401s.

## Test plan

- [x] `npm test` — 210 pass (was 201; +9 backup-gate tests)
- [ ] After merge + adding the secret: trigger the workflow manually (Actions → Cron backup → Run workflow). While Cloudflare's cron is healthy, both steps should report `Backup skipped`.
- [ ] During the current Cloudflare outage, confirm the workflow's `/api/cron?backup=1` call writes a fresh `mlb_cron_runs` row.

https://claude.ai/code/session_01GPWogtU8y4upCGZpzUiqHp

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPWogtU8y4upCGZpzUiqHp)_