### PR TITLE
Team landing pages at /teams/[slug] for SEO and signup conversion

### DIFF
--- a/app/api/login/route.js
+++ b/app/api/login/route.js
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase-server";
+import { TEAMS_BY_SLUG } from "@/lib/teams";
 import { NextResponse } from "next/server";
 
 const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
@@ -60,9 +61,19 @@ export async function POST(request) {
 
   const origin = process.env.SITE_URL || new URL(request.url).origin;
 
+  // Team-landing CTAs (#195) pass a team slug so the dashboard can pre-select
+  // it on first load. Validate against the slug table — anything unknown is
+  // silently dropped rather than reflected back into the redirect URL.
+  const teamSlug =
+    typeof payload?.team === "string" && TEAMS_BY_SLUG[payload.team]
+      ? payload.team
+      : null;
+  const callbackUrl = new URL(`${origin}/auth/callback`);
+  if (teamSlug) callbackUrl.searchParams.set("team", teamSlug);
+
   const { error } = await supabase.auth.signInWithOtp({
     email,
-    options: { emailRedirectTo: `${origin}/auth/callback` },
+    options: { emailRedirectTo: callbackUrl.toString() },
   });
 
   if (error) {

--- a/app/api/login/route.test.js
+++ b/app/api/login/route.test.js
@@ -151,4 +151,37 @@ describe("POST /api/login", () => {
     expect(res.status).toBe(200);
     expect(signInWithOtp).toHaveBeenCalledTimes(1);
   });
+
+  it("appends ?team=<slug> to emailRedirectTo for a known slug (#195)", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      makeRequest({ email: "user@example.com", team: "mariners" })
+    );
+
+    expect(res.status).toBe(200);
+    expect(signInWithOtp).toHaveBeenCalledWith({
+      email: "user@example.com",
+      options: {
+        emailRedirectTo:
+          "https://ninthinning.email/auth/callback?team=mariners",
+      },
+    });
+  });
+
+  it("drops an unknown team slug rather than reflecting it back", async () => {
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      makeRequest({ email: "user@example.com", team: "not-a-team" })
+    );
+
+    expect(res.status).toBe(200);
+    expect(signInWithOtp).toHaveBeenCalledWith({
+      email: "user@example.com",
+      options: {
+        emailRedirectTo: "https://ninthinning.email/auth/callback",
+      },
+    });
+  });
 });

--- a/app/auth/callback/route.js
+++ b/app/auth/callback/route.js
@@ -1,9 +1,12 @@
 import { createClient } from "@/lib/supabase-server";
+import { TEAMS_BY_SLUG } from "@/lib/teams";
 import { NextResponse } from "next/server";
 
 export async function GET(request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
+  const teamParam = searchParams.get("team");
+  const team = teamParam && TEAMS_BY_SLUG[teamParam] ? teamParam : null;
 
   let isNewSignup = false;
 
@@ -23,5 +26,6 @@ export async function GET(request) {
 
   const dest = new URL(`${origin}/dashboard`);
   if (isNewSignup) dest.searchParams.set("signup", "1");
+  if (team) dest.searchParams.set("team", team);
   return NextResponse.redirect(dest);
 }

--- a/app/dashboard/team-grid.js
+++ b/app/dashboard/team-grid.js
@@ -1,14 +1,38 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { createClient } from "@/lib/supabase-browser";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { track } from "@/lib/analytics";
+import { TEAMS_BY_SLUG } from "@/lib/teams";
 
 export default function TeamGrid({ teams, followedIds: initialFollowed }) {
   const [followed, setFollowed] = useState(new Set(initialFollowed));
   const [, startTransition] = useTransition();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const preselectHandled = useRef(false);
+
+  // Pre-select from /teams/[slug] CTA. The team-landing pages (#195) thread a
+  // ?team=<slug> param through login → callback → here; if the user isn't
+  // already following that team we follow it once and strip the param so a
+  // refresh doesn't re-trigger.
+  useEffect(() => {
+    if (preselectHandled.current) return;
+    const slug = searchParams.get("team");
+    if (!slug) return;
+    preselectHandled.current = true;
+    const team = TEAMS_BY_SLUG[slug];
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("team");
+    const nextUrl = params.toString() ? `/dashboard?${params}` : "/dashboard";
+    if (team && !followed.has(team.id)) {
+      toggle(team.id).finally(() => router.replace(nextUrl));
+    } else {
+      router.replace(nextUrl);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function toggle(teamId) {
     const supabase = createClient();

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -8,6 +8,7 @@ import { BrandLockup } from "@/components/brand";
 function LoginForm() {
   const searchParams = useSearchParams();
   const isSignup = searchParams.get("next") === "signup";
+  const team = searchParams.get("team") || "";
   const [email, setEmail] = useState("");
   const [sent, setSent] = useState(false);
   const [error, setError] = useState(null);
@@ -23,7 +24,7 @@ function LoginForm() {
       res = await fetch("/api/login", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, team }),
       });
     } catch {
       setLoading(false);

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,3 +1,5 @@
+import { MLB_TEAMS } from "@/lib/teams";
+
 const SITE_URL = process.env.SITE_URL || "https://ninthinning.email";
 
 export default function sitemap() {
@@ -7,6 +9,11 @@ export default function sitemap() {
       changeFrequency: "weekly",
       priority: 1,
     },
+    ...MLB_TEAMS.map((t) => ({
+      url: `${SITE_URL}/teams/${t.slug}`,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    })),
     {
       url: `${SITE_URL}/privacy`,
       changeFrequency: "yearly",

--- a/app/teams/[slug]/page.js
+++ b/app/teams/[slug]/page.js
@@ -1,0 +1,216 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { BrandLockup, DiamondGlyph } from "@/components/brand";
+import { MLB_TEAMS, TEAMS_BY_SLUG } from "@/lib/teams";
+import { createClient } from "@/lib/supabase-server";
+
+const SITE_URL = process.env.SITE_URL || "https://ninthinning.email";
+
+export function generateStaticParams() {
+  return MLB_TEAMS.map((t) => ({ slug: t.slug }));
+}
+
+// Generate at build time only; static across deploys.
+export const dynamicParams = false;
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params;
+  const team = TEAMS_BY_SLUG[slug];
+  if (!team) return {};
+  const title = `Spoiler-free ${team.name} highlights by email`;
+  const description = `Follow the ${team.shortName} without spoilers. Ninth Inning Email sends you the official MLB recap the morning after every ${team.shortName} game — no scores, no winner, just the highlights when you press play.`;
+  const url = `${SITE_URL}/teams/${team.slug}`;
+  return {
+    title,
+    description,
+    alternates: { canonical: `/teams/${team.slug}` },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "Ninth Inning Email",
+      type: "website",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+    },
+  };
+}
+
+export default async function TeamLandingPage({ params }) {
+  const { slug } = await params;
+  const team = TEAMS_BY_SLUG[slug];
+  if (!team) notFound();
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const isSignedIn = Boolean(user);
+  const ctaHref = isSignedIn
+    ? `/dashboard?team=${team.slug}`
+    : `/login?next=signup&team=${team.slug}`;
+  const ctaLabel = isSignedIn
+    ? `Follow the ${team.shortName}`
+    : `Get spoiler-free ${team.shortName} recaps`;
+
+  return (
+    <div className="min-h-screen">
+      <header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
+        <Link
+          href="/"
+          aria-label="ninthinning.email"
+          className="text-[15px] text-[#f7f5ef]"
+        >
+          <BrandLockup glyphSize={28} dark />
+        </Link>
+        <Link
+          href={isSignedIn ? "/dashboard" : "/login"}
+          className="text-sm font-medium text-[#a8a299] transition hover:text-[#f7f5ef]"
+        >
+          {isSignedIn ? "Dashboard" : "Sign in"}
+        </Link>
+      </header>
+
+      {/* Hero with team color accent */}
+      <section className="relative overflow-hidden">
+        <div
+          className="pointer-events-none absolute inset-0 -z-10 opacity-60"
+          style={{
+            background: `radial-gradient(ellipse 80% 50% at 50% -10%, ${team.color}55, transparent 70%)`,
+          }}
+          aria-hidden="true"
+        />
+        <div className="mx-auto max-w-4xl px-6 pb-16 pt-10 sm:pt-16 lg:pt-20">
+          <div className="text-center">
+            <span
+              className="inline-block rounded px-3 py-1 text-xs font-bold uppercase tracking-wider text-white"
+              style={{ backgroundColor: team.color }}
+            >
+              {team.abbr}
+            </span>
+            <h1 className="mt-5 text-4xl font-bold tracking-tight text-[#f7f5ef] sm:text-5xl lg:text-6xl">
+              Get spoiler-free {team.name} highlights by email.
+            </h1>
+            <p className="mx-auto mt-5 max-w-2xl text-lg text-[#a8a299] sm:text-xl">
+              Follow the {team.shortName} without waking up to spoiled scores.
+              Ninth Inning Email sends you the official MLB recap the morning
+              after every {team.shortName} game — no score, no winner, no push
+              notifications.
+            </p>
+            <div className="mt-8 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+              <Link
+                href={ctaHref}
+                className="w-full rounded-lg px-6 py-3 text-center text-sm font-semibold text-white shadow-lg transition hover:opacity-90 sm:w-auto"
+                style={{ backgroundColor: team.color }}
+              >
+                {ctaLabel}
+              </Link>
+              <Link
+                href="/#sample"
+                className="text-sm font-medium text-[#a8a299] transition hover:text-[#f7f5ef]"
+              >
+                See a sample email &amp; recap &rarr;
+              </Link>
+            </div>
+            <p className="mt-4 text-xs text-[#a8a299]">
+              Free · No ads · Unsubscribe anytime
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works for this team */}
+      <section className="mx-auto max-w-3xl px-6 pb-16 sm:pb-20">
+        <h2 className="text-center text-2xl font-bold tracking-tight text-[#f7f5ef] sm:text-3xl">
+          How it works for {team.shortName} fans
+        </h2>
+        <ul className="mx-auto mt-8 max-w-2xl space-y-3 text-[#a8a299]">
+          {[
+            `Pick the ${team.shortName} (and any other MLB teams) on your dashboard.`,
+            `The morning after every ${team.shortName} game, we email you one spoiler-free recap.`,
+            "The subject line and preview text never reveal the score.",
+            "Tap through to a branded page on ninthinning.email — still no score on screen.",
+            "Press play to watch the 3–5 minute official MLB recap on your schedule.",
+          ].map((item) => (
+            <li key={item} className="flex items-start gap-3">
+              <span
+                aria-hidden="true"
+                className="mt-2 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full"
+                style={{ backgroundColor: team.color }}
+              />
+              <span className="text-base">{item}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Spoiler-safe promise — reused from the home page so the trust copy is consistent */}
+      <section className="border-y border-[#1f3a2c] bg-[#0f1311]/60">
+        <div className="mx-auto max-w-3xl px-6 py-16 sm:py-20">
+          <div className="rounded-2xl border border-[#3f6e57]/50 bg-[#0f2a1f]/60 p-8 sm:p-10">
+            <div className="flex items-center gap-3">
+              <DiamondGlyph size={28} />
+              <h2 className="text-xl font-bold tracking-tight text-[#f7f5ef] sm:text-2xl">
+                Spoiler-safe promise
+              </h2>
+            </div>
+            <p className="mt-5 text-base leading-relaxed text-[#a8a299] sm:text-lg">
+              No scores, no winner, no losing pitcher, no &ldquo;walk-off win&rdquo;
+              language, no comeback hints, and no subject lines that give away
+              what happened. The email and delivery are spoiler-free; the
+              video is the official MLB recap, which of course shows the score
+              once you press play — you decide when that happens.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="mx-auto max-w-6xl px-6 py-20">
+        <div
+          className="rounded-3xl border px-6 py-14 text-center sm:px-12"
+          style={{
+            borderColor: `${team.color}55`,
+            background: `linear-gradient(135deg, ${team.color}22, #0f2a1f55)`,
+          }}
+        >
+          <h2 className="text-3xl font-bold tracking-tight text-[#f7f5ef] sm:text-4xl">
+            Ready for spoiler-free {team.shortName} recaps?
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-[#a8a299]">
+            Sign in with a magic link — we&apos;ll pre-select the {team.shortName} so you can start with one click.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <Link
+              href={ctaHref}
+              className="rounded-lg px-8 py-3.5 text-sm font-semibold text-white shadow-lg transition hover:opacity-90"
+              style={{ backgroundColor: team.color }}
+            >
+              {ctaLabel}
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <footer className="border-t border-[#1f3a2c]">
+        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 py-8 text-xs text-[#a8a299] sm:flex-row">
+          <p className="text-center sm:text-left">
+            Ninth Inning Email is not affiliated with, endorsed by, or sponsored
+            by MLB or any MLB club. Video links courtesy of MLB.com.
+          </p>
+          <div className="flex items-center gap-5">
+            <Link href="/" className="transition hover:text-[#f7f5ef]">
+              Home
+            </Link>
+            <Link href="/privacy" className="transition hover:text-[#f7f5ef]">
+              Privacy
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/lib/teams.js
+++ b/lib/teams.js
@@ -1,37 +1,45 @@
-// All 30 MLB teams with their Stats API team IDs and brand colors
+// All 30 MLB teams with their Stats API team IDs and brand colors.
+// `slug` is the URL identifier used by /teams/[slug] landing pages (#195).
+// Derived from shortName: lowercased, spaces → hyphens. Stable — once a slug
+// is shipped it is part of the site's URL surface and cannot change without a
+// redirect.
 export const MLB_TEAMS = [
-  { id: 109, name: "Arizona Diamondbacks", shortName: "Diamondbacks", abbr: "ARI", color: "#A71930" },
-  { id: 144, name: "Atlanta Braves", shortName: "Braves", abbr: "ATL", color: "#CE1141" },
-  { id: 110, name: "Baltimore Orioles", shortName: "Orioles", abbr: "BAL", color: "#DF4601" },
-  { id: 111, name: "Boston Red Sox", shortName: "Red Sox", abbr: "BOS", color: "#BD3039" },
-  { id: 112, name: "Chicago Cubs", shortName: "Cubs", abbr: "CHC", color: "#0E3386" },
-  { id: 145, name: "Chicago White Sox", shortName: "White Sox", abbr: "CWS", color: "#27251F" },
-  { id: 113, name: "Cincinnati Reds", shortName: "Reds", abbr: "CIN", color: "#C6011F" },
-  { id: 114, name: "Cleveland Guardians", shortName: "Guardians", abbr: "CLE", color: "#00385D" },
-  { id: 115, name: "Colorado Rockies", shortName: "Rockies", abbr: "COL", color: "#333366" },
-  { id: 116, name: "Detroit Tigers", shortName: "Tigers", abbr: "DET", color: "#0C2340" },
-  { id: 117, name: "Houston Astros", shortName: "Astros", abbr: "HOU", color: "#002D62" },
-  { id: 118, name: "Kansas City Royals", shortName: "Royals", abbr: "KC", color: "#004687" },
-  { id: 108, name: "Los Angeles Angels", shortName: "Angels", abbr: "LAA", color: "#BA0021" },
-  { id: 119, name: "Los Angeles Dodgers", shortName: "Dodgers", abbr: "LAD", color: "#005A9C" },
-  { id: 146, name: "Miami Marlins", shortName: "Marlins", abbr: "MIA", color: "#00A3E0" },
-  { id: 158, name: "Milwaukee Brewers", shortName: "Brewers", abbr: "MIL", color: "#FFC52F" },
-  { id: 142, name: "Minnesota Twins", shortName: "Twins", abbr: "MIN", color: "#002B5C" },
-  { id: 121, name: "New York Mets", shortName: "Mets", abbr: "NYM", color: "#002D72" },
-  { id: 147, name: "New York Yankees", shortName: "Yankees", abbr: "NYY", color: "#003087" },
-  { id: 133, name: "Oakland Athletics", shortName: "Athletics", abbr: "OAK", color: "#003831" },
-  { id: 143, name: "Philadelphia Phillies", shortName: "Phillies", abbr: "PHI", color: "#E81828" },
-  { id: 134, name: "Pittsburgh Pirates", shortName: "Pirates", abbr: "PIT", color: "#27251F" },
-  { id: 135, name: "San Diego Padres", shortName: "Padres", abbr: "SD", color: "#2F241D" },
-  { id: 137, name: "San Francisco Giants", shortName: "Giants", abbr: "SF", color: "#FD5A1E" },
-  { id: 136, name: "Seattle Mariners", shortName: "Mariners", abbr: "SEA", color: "#0C2C56" },
-  { id: 138, name: "St. Louis Cardinals", shortName: "Cardinals", abbr: "STL", color: "#C41E3A" },
-  { id: 139, name: "Tampa Bay Rays", shortName: "Rays", abbr: "TB", color: "#092C5C" },
-  { id: 140, name: "Texas Rangers", shortName: "Rangers", abbr: "TEX", color: "#003278" },
-  { id: 141, name: "Toronto Blue Jays", shortName: "Blue Jays", abbr: "TOR", color: "#134A8E" },
-  { id: 120, name: "Washington Nationals", shortName: "Nationals", abbr: "WSH", color: "#AB0003" },
+  { id: 109, name: "Arizona Diamondbacks", shortName: "Diamondbacks", abbr: "ARI", color: "#A71930", slug: "diamondbacks" },
+  { id: 144, name: "Atlanta Braves", shortName: "Braves", abbr: "ATL", color: "#CE1141", slug: "braves" },
+  { id: 110, name: "Baltimore Orioles", shortName: "Orioles", abbr: "BAL", color: "#DF4601", slug: "orioles" },
+  { id: 111, name: "Boston Red Sox", shortName: "Red Sox", abbr: "BOS", color: "#BD3039", slug: "red-sox" },
+  { id: 112, name: "Chicago Cubs", shortName: "Cubs", abbr: "CHC", color: "#0E3386", slug: "cubs" },
+  { id: 145, name: "Chicago White Sox", shortName: "White Sox", abbr: "CWS", color: "#27251F", slug: "white-sox" },
+  { id: 113, name: "Cincinnati Reds", shortName: "Reds", abbr: "CIN", color: "#C6011F", slug: "reds" },
+  { id: 114, name: "Cleveland Guardians", shortName: "Guardians", abbr: "CLE", color: "#00385D", slug: "guardians" },
+  { id: 115, name: "Colorado Rockies", shortName: "Rockies", abbr: "COL", color: "#333366", slug: "rockies" },
+  { id: 116, name: "Detroit Tigers", shortName: "Tigers", abbr: "DET", color: "#0C2340", slug: "tigers" },
+  { id: 117, name: "Houston Astros", shortName: "Astros", abbr: "HOU", color: "#002D62", slug: "astros" },
+  { id: 118, name: "Kansas City Royals", shortName: "Royals", abbr: "KC", color: "#004687", slug: "royals" },
+  { id: 108, name: "Los Angeles Angels", shortName: "Angels", abbr: "LAA", color: "#BA0021", slug: "angels" },
+  { id: 119, name: "Los Angeles Dodgers", shortName: "Dodgers", abbr: "LAD", color: "#005A9C", slug: "dodgers" },
+  { id: 146, name: "Miami Marlins", shortName: "Marlins", abbr: "MIA", color: "#00A3E0", slug: "marlins" },
+  { id: 158, name: "Milwaukee Brewers", shortName: "Brewers", abbr: "MIL", color: "#FFC52F", slug: "brewers" },
+  { id: 142, name: "Minnesota Twins", shortName: "Twins", abbr: "MIN", color: "#002B5C", slug: "twins" },
+  { id: 121, name: "New York Mets", shortName: "Mets", abbr: "NYM", color: "#002D72", slug: "mets" },
+  { id: 147, name: "New York Yankees", shortName: "Yankees", abbr: "NYY", color: "#003087", slug: "yankees" },
+  { id: 133, name: "Oakland Athletics", shortName: "Athletics", abbr: "OAK", color: "#003831", slug: "athletics" },
+  { id: 143, name: "Philadelphia Phillies", shortName: "Phillies", abbr: "PHI", color: "#E81828", slug: "phillies" },
+  { id: 134, name: "Pittsburgh Pirates", shortName: "Pirates", abbr: "PIT", color: "#27251F", slug: "pirates" },
+  { id: 135, name: "San Diego Padres", shortName: "Padres", abbr: "SD", color: "#2F241D", slug: "padres" },
+  { id: 137, name: "San Francisco Giants", shortName: "Giants", abbr: "SF", color: "#FD5A1E", slug: "giants" },
+  { id: 136, name: "Seattle Mariners", shortName: "Mariners", abbr: "SEA", color: "#0C2C56", slug: "mariners" },
+  { id: 138, name: "St. Louis Cardinals", shortName: "Cardinals", abbr: "STL", color: "#C41E3A", slug: "cardinals" },
+  { id: 139, name: "Tampa Bay Rays", shortName: "Rays", abbr: "TB", color: "#092C5C", slug: "rays" },
+  { id: 140, name: "Texas Rangers", shortName: "Rangers", abbr: "TEX", color: "#003278", slug: "rangers" },
+  { id: 141, name: "Toronto Blue Jays", shortName: "Blue Jays", abbr: "TOR", color: "#134A8E", slug: "blue-jays" },
+  { id: 120, name: "Washington Nationals", shortName: "Nationals", abbr: "WSH", color: "#AB0003", slug: "nationals" },
 ];
 
 export const TEAMS_BY_ID = Object.fromEntries(
   MLB_TEAMS.map((t) => [t.id, t])
+);
+
+export const TEAMS_BY_SLUG = Object.fromEntries(
+  MLB_TEAMS.map((t) => [t.slug, t])
 );

--- a/lib/teams.test.js
+++ b/lib/teams.test.js
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { MLB_TEAMS, TEAMS_BY_ID } from "./teams";
+import { MLB_TEAMS, TEAMS_BY_ID, TEAMS_BY_SLUG } from "./teams";
 
 describe("MLB_TEAMS", () => {
   it("contains exactly 30 teams", () => {
     expect(MLB_TEAMS).toHaveLength(30);
   });
 
-  it("gives every team an id, name, shortName, abbr, and a hex color", () => {
+  it("gives every team an id, name, shortName, abbr, hex color, and slug", () => {
     for (const team of MLB_TEAMS) {
       expect(typeof team.id).toBe("number");
       expect(team.name).toBeTruthy();
@@ -14,6 +14,7 @@ describe("MLB_TEAMS", () => {
       expect(team.name).toContain(team.shortName);
       expect(team.abbr).toBeTruthy();
       expect(team.color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+      expect(team.slug).toMatch(/^[a-z][a-z-]*[a-z]$/);
     }
   });
 
@@ -31,6 +32,11 @@ describe("MLB_TEAMS", () => {
     const names = MLB_TEAMS.map((t) => t.name);
     expect(new Set(names).size).toBe(names.length);
   });
+
+  it("has unique slugs", () => {
+    const slugs = MLB_TEAMS.map((t) => t.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
 });
 
 describe("TEAMS_BY_ID", () => {
@@ -44,5 +50,19 @@ describe("TEAMS_BY_ID", () => {
   it("returns undefined for unknown ids", () => {
     expect(TEAMS_BY_ID[0]).toBeUndefined();
     expect(TEAMS_BY_ID[999999]).toBeUndefined();
+  });
+});
+
+describe("TEAMS_BY_SLUG", () => {
+  it("indexes every team by slug", () => {
+    expect(Object.keys(TEAMS_BY_SLUG)).toHaveLength(MLB_TEAMS.length);
+    for (const team of MLB_TEAMS) {
+      expect(TEAMS_BY_SLUG[team.slug]).toBe(team);
+    }
+  });
+
+  it("returns undefined for unknown slugs", () => {
+    expect(TEAMS_BY_SLUG["not-a-team"]).toBeUndefined();
+    expect(TEAMS_BY_SLUG[""]).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #195.

## Summary

30 statically generated landing pages — one per MLB team — each optimized for long-tail queries like "spoiler-free Mariners highlights". Each page carries a team-color hero, team-specific copy, per-team SEO metadata, and a CTA that threads the team selection through the magic-link sign-in so the dashboard pre-follows that team on first arrival.

- **`lib/teams.js`** — stable `slug` per team plus a `TEAMS_BY_SLUG` lookup. Slugs derived from `shortName` (lowercased, spaces → hyphens). Comment in-source flags them as part of the URL surface and not safe to change without a redirect.
- **`app/teams/[slug]/page.js`** — SSG via `generateStaticParams`, `dynamicParams = false`, per-team `generateMetadata` (title, description, canonical, OG, Twitter), `notFound()` on unknown slug. Team-color hero accent + abbr chip, team-specific headline/copy, reused Spoiler-safe promise block, "How it works for {team} fans" list, final CTA with team-color gradient. Sample-email anchor links back to `/#sample` so we don't duplicate the home-page mocks.
- **`app/sitemap.js`** — all 30 team URLs included at `priority: 0.7`, `changeFrequency: monthly`.
- **Pre-select flow** — `/teams/[slug]` CTA links to `/login?next=signup&team=<slug>` (or directly to `/dashboard?team=<slug>` if already signed in). `/api/login` validates the slug against `TEAMS_BY_SLUG` and appends `?team=<slug>` to `emailRedirectTo`. `/auth/callback` preserves the param. The dashboard `TeamGrid` reads the param on mount, calls the existing idempotent `toggle()` (writes to `mlb_user_teams`; welcome-email sentinel keeps re-arrivals safe), then strips the param via `router.replace` so a refresh can't re-trigger. Unknown slugs are silently dropped at the API edge.

Build confirms all 30 pages prerender at build time (`/teams/diamondbacks`, `/teams/braves`, `/teams/orioles`, +27 more). Full test suite green at **215 passed (19 files)**, including 5 new tests covering slug uniqueness, `TEAMS_BY_SLUG`, and the `/api/login` slug threading (known + unknown).

## Notes for review

- Supabase's Auth → URL Configuration → Redirect URLs allowlist matches on the base URL, so the existing `https://ninthinning.email/auth/callback` entry should accept the new `?team=…` query string without an allowlist change. Worth a once-through in staging before announcing the pages.
- The pre-select effect lives in the existing `TeamGrid` client component rather than spawning a new island — it reuses the same idempotent insert path used for manual toggling, so analytics (`team_selected`) and the welcome-email side effect fire consistently with a manual click.
- Per-team pages **are** indexable (unlike `/highlights/[gamePk]`, which is `robots: { index: false }`) — that's the point.

## Test plan

- [ ] Visit `/teams/mariners`, `/teams/yankees`, `/teams/red-sox`, `/teams/blue-jays` — each renders with the correct team color, abbr chip, and copy
- [ ] Visit `/teams/not-a-team` → 404
- [ ] Signed-out: click CTA → `/login?next=signup&team=mariners` → submit → magic link arrives → callback lands on `/dashboard?team=mariners&signup=1` → Mariners is pre-followed, URL strips to `/dashboard`
- [ ] Signed-in: click CTA → `/dashboard?team=mariners` → Mariners is added (or no-op if already followed), URL strips
- [ ] `/sitemap.xml` lists all 30 team URLs
- [ ] View-source on a team page: `<title>`, meta description, `<link rel="canonical">`, OG tags all team-specific

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lhv2rCtbLU6Qpar46htAEY)_